### PR TITLE
Make Bn_382 tests compile conditionally

### DIFF
--- a/algebra/src/curves/bn_382/mod.rs
+++ b/algebra/src/curves/bn_382/mod.rs
@@ -1,5 +1,6 @@
 pub mod g1;
 pub mod g2;
+#[cfg(test)]
 mod tests;
 
 use crate::{


### PR DESCRIPTION
Currently build fails locally for me without this, since the `crate::curves::tests` crate is only exposed for `#[cfg(test)]`.