### PR TITLE
experimental work on EC operations optimizations

### DIFF
--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -25,8 +25,9 @@ edition = "2018"
 byteorder = { version = "1" }
 rand = { version = "0.7" }
 derivative = { version = "1" }
+rand_core = { version = "0.5" }
+colored = "1.9.2"
 
-colored = { version = "1", optional = true }
 rayon = { version = "1", optional = true }
 clippy = { version = "*", optional = true }
 

--- a/algebra/src/curves/mod.rs
+++ b/algebra/src/curves/mod.rs
@@ -234,7 +234,7 @@ pub trait AffineCurve:
 
     // currently ony implemented for Bn-382
     fn add_batch(_: &mut Vec<Self>) -> Self {Self::zero()}
-    fn add_points(_: &mut [Vec<Self>]) -> Vec<Self> {Vec::new()}
+    fn add_points(_: &mut [Vec<Self>]) {}
 }
 
 pub trait PairingCurve: AffineCurve {

--- a/algebra/src/curves/mod.rs
+++ b/algebra/src/curves/mod.rs
@@ -231,6 +231,9 @@ pub trait AffineCurve:
     /// `Self::ScalarField`.
     #[must_use]
     fn mul_by_cofactor_inv(&self) -> Self;
+
+    // currently ony implemented for Bn-382
+    fn add_points(_: Vec<Vec<Self>>) -> Vec<Self> {Vec::new()}
 }
 
 pub trait PairingCurve: AffineCurve {

--- a/algebra/src/curves/mod.rs
+++ b/algebra/src/curves/mod.rs
@@ -233,7 +233,8 @@ pub trait AffineCurve:
     fn mul_by_cofactor_inv(&self) -> Self;
 
     // currently ony implemented for Bn-382
-    fn add_points(_: Vec<Vec<Self>>) -> Vec<Self> {Vec::new()}
+    fn add_batch(_: &mut Vec<Self>) -> Self {Self::zero()}
+    fn add_points(_: &mut Vec<Vec<Self>>) -> Vec<Self> {Vec::new()}
 }
 
 pub trait PairingCurve: AffineCurve {

--- a/algebra/src/curves/mod.rs
+++ b/algebra/src/curves/mod.rs
@@ -234,7 +234,7 @@ pub trait AffineCurve:
 
     // currently ony implemented for Bn-382
     fn add_batch(_: &mut Vec<Self>) -> Self {Self::zero()}
-    fn add_points(_: &mut Vec<Vec<Self>>) -> Vec<Self> {Vec::new()}
+    fn add_points(_: &mut [Vec<Self>]) -> Vec<Self> {Vec::new()}
 }
 
 pub trait PairingCurve: AffineCurve {

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -145,13 +145,81 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
         (*self).into()
     }
 
+    // this function adds allgroup elements together,
+    //  using Affinepoint arithmetic, producing theeir sum
+    fn add_batch(p: &mut Vec<Self>) -> Self
+    {
+        while p.len() > 1
+        {
+            let len = if p.len()%2 == 0 {p.len()} else {p.len()-1};
+            let mut denominators = p.chunks_exact_mut(2).map
+            (
+                |p|
+                if p[0].x == p[1].x
+                {
+                    if p[1].y == P::BaseField::zero() {P::BaseField::one()} else {p[1].y.double()}
+                } else {p[0].x - &p[1].x}
+            ).collect::<Vec<_>>();
+
+            crate::fields::batch_inversion::<P::BaseField>(&mut denominators);
+
+            for (i, d) in (0..len).step_by(2).zip(denominators.iter())
+            {
+                let j = i/2;
+                if p[i+1].is_zero() == true
+                {
+                    p[j] = p[i];
+                }
+                else if p[i].is_zero() == true
+                {
+                    p[j] = p[i+1];
+                }
+                else if p[i+1].x == p[i].x && (p[i+1].y != p[i].y || p[i+1].y == P::BaseField::zero())
+                {
+                    p[j] = Self::zero();
+                }
+                else if p[i+1].x == p[i].x && p[i+1].y == p[i].y
+                {
+                    let sq = p[i].x.square();
+                    let s = (sq.double() + &sq + &P::COEFF_A) * d;
+                    let x = s.square() - &p[i].x.double();
+                    let y = -p[i].y - &(s * &(x - &p[i].x));
+                    p[j].x = x;
+                    p[j].y = y;
+                }
+                else
+                {
+                    let s = (p[i].y - &p[i+1].y) * d;
+                    let x = s.square() - &p[i].x - &p[i+1].x;
+                    let y = -p[i].y - &(s * &(x - &p[i].x));
+                    p[j].x = x;
+                    p[j].y = y;
+                }
+            }
+
+            let len = p.len();
+            if len % 2 == 1
+            {
+                p[len/2] = p[len-1];
+                p.truncate(len/2+1);
+            }
+            else
+            {
+                p.truncate(len/2);
+            }
+        }
+        if p.len() == 0 {Self::zero()} else {p.remove(0)}
+    }
+
     // this function adds, for each vector of 'vectors', its elements
     // together, using Affine point arithmetic, producing the vector of sums
-    fn add_points(mut vectors: Vec<Vec<Self>>) -> Vec<Self>
+    fn add_points (vectors: &mut Vec<Vec<Self>>) -> Vec<Self>
     {
+        let length = vectors.iter().map(|l| l.len()).fold(0, |x, y| x + y);
+        let mut denoms = Vec::<P::BaseField>::with_capacity(length / 2);
+
         while vectors.iter().position(|x| x.len() > 1) != None
         {
-            let mut denoms = Vec::new();
             for p in vectors.iter_mut()
             {
                 if p.len() < 2 {continue}

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -215,26 +215,17 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     // together, using Affine point arithmetic, producing the vector of sums
     fn add_points (vectors: &mut [Vec<Self>]) -> Vec<Self>
     {
-        vectors.iter_mut().for_each(|v| if v.len() == 0 {*v = vec![Self::zero()]});
-        let mut lengths = vectors.iter().map(|l| l.len()).collect::<Vec<_>>();
-        let length = lengths.iter().map(|l| l).fold(0, |x, y| x + y);
+        let length = vectors.iter().map(|l| l.len()).fold(0, |x, y| x + y);
         let mut denoms = vec![P::BaseField::zero(); length / 2];
-        let mut p = Vec::<Self>::with_capacity(length);
 
-        let mut offset: usize = 0;
-        let offsets = lengths.iter().map(|l| {let ret = offset; offset += l; ret}).collect::<Vec<_>>();
-        vectors.iter_mut().for_each(|mut v| p.append(&mut v));
-
-        // we have flattened vectors (vector of vectors) into p (flat vector)
-
-        while lengths.iter().position(|&l| l > 1) != None
+        while vectors.iter().position(|x| x.len() > 1) != None
         {
             let mut dx: usize = 0;
-            for (&off, &plen) in offsets.iter().zip(lengths.iter())
+            for p in vectors.iter_mut()
             {
-                if plen < 2 {continue}
-                let len = if plen%2 == 0 {plen} else {plen-1};
-                for i in (off..off+len).step_by(2)
+                if p.len() < 2 {continue}
+                let len = if p.len()%2 == 0 {p.len()} else {p.len()-1};
+                for i in (0..len).step_by(2)
                 {
                     denoms[dx] =
                     if p[i].x == p[i+1].x
@@ -249,14 +240,14 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
             crate::fields::batch_inversion::<P::BaseField>(&mut denoms);
             dx = 0;
 
-            for (&off, plen) in offsets.iter().zip(lengths.iter_mut())
+            for p in vectors.iter_mut()
             {
-                if *plen < 2 {continue}
-                let len = if *plen%2 == 0 {*plen} else {*plen-1};
+                if p.len() < 2 {continue}
+                let len = if p.len()%2 == 0 {p.len()} else {p.len()-1};  
                 
-                for i in (off..off+len).step_by(2)
+                for i in (0..len).step_by(2)
                 {
-                    let j = (off+i)/2;
+                    let j = i/2;
                     if p[i+1].is_zero() == true
                     {
                         p[j] = p[i];
@@ -289,19 +280,19 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
                     dx += 1;
                 }
 
-                let len = *plen;
-                if *plen % 2 == 1
+                let len = p.len();
+                if len % 2 == 1
                 {
-                    p[off + len/2] = p[off + len-1];
-                    *plen = len/2+1;
+                    p[len/2] = p[len-1];
+                    p.truncate(len/2+1);
                 }
                 else
                 {
-                    *plen = len/2;
+                    p.truncate(len/2);
                 }
             }
         }
-        offsets.iter().map(|&o| p[o]).collect()
+        vectors.iter().map(|x| if x.len() == 0 {Self::zero()} else {x[0]}).collect()
     }
 }
 

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -212,8 +212,8 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     }
 
     // this function adds, for each vector of 'vectors', its elements
-    // together, using Affine point arithmetic, producing the vector of sums
-    fn add_points (vectors: &mut [Vec<Self>]) -> Vec<Self>
+    // together, using Affine point arithmetic, reducing to the vector of sums
+    fn add_points (vectors: &mut [Vec<Self>])
     {
         let length = vectors.iter().map(|l| l.len()).fold(0, |x, y| x + y);
         let mut denoms = vec![P::BaseField::zero(); length / 2];
@@ -292,7 +292,6 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
                 }
             }
         }
-        vectors.iter().map(|x| if x.len() == 0 {Self::zero()} else {x[0]}).collect()
     }
 }
 

--- a/algebra/src/msm/variable_base.rs
+++ b/algebra/src/msm/variable_base.rs
@@ -23,20 +23,21 @@ impl VariableBaseMSM {
         let fr_one = G::ScalarField::one().into_repr();
 
         let zero = G::zero().into_projective();
-        let window_starts: Vec<_> = (0..num_bits).step_by(c).collect();
+        let mut buckets = vec![Vec::<G>::with_capacity(bases.len()/cc); cc];
 
+        let window_starts: Vec<_> = (0..num_bits).step_by(c).collect();
         // Each window is of size `c`.
         // We divide up the bits 0..num_bits into windows of size `c`, and
         // in parallel process each such window.
+
         let window_sums: Vec<_> = window_starts
-            .into_par_iter()
+            .into_iter()
             .map(|w_start| {
-                // We don't need the "zero" bucket, we use 2^c-1 bucket for units
-                let mut buckets = vec![Vec::with_capacity(bases.len()*c/cc); cc];
                 scalars.iter().zip(bases).filter(|(s, _)| !s.is_zero()).for_each(|(&scalar, base)|  {
+                                        
                     if scalar == fr_one {
                         // We only process unit scalars once in the first window.
-                        if w_start == 0 && base.is_zero() == false {
+                        if w_start == 0 {
                             buckets[cc-1].push(*base);
                         }
                     } else {
@@ -52,27 +53,20 @@ impl VariableBaseMSM {
                         // If the scalar is non-zero, we update the corresponding
                         // bucket.
                         // (Recall that `buckets` doesn't have a zero bucket.)
-                        if scalar != 0 && base.is_zero() == false {
+                        if scalar != 0 {
                             buckets[(scalar - 1) as usize].push(*base);
                         }
                     }
                 });
-                let mut buckets = G::add_points(buckets);
-                let mut res = Vec::with_capacity(cc*(cc-1)/2+1);
-                if buckets[cc-1].is_zero() == false {
-                    res.push(buckets[cc-1])
+                let mut bucketsums = buckets.par_iter_mut().map(|mut b| G::add_batch(&mut b)).collect::<Vec<_>>();
+                let mut res = bucketsums.remove(cc-1).into_projective();
+ 
+                let mut running_sum = G::Projective::zero();
+                for b in bucketsums.iter().rev() {
+                    running_sum.add_assign_mixed(b);
+                    res += &running_sum;
                 }
-                buckets.truncate(cc-1);
-
-                let mut running_sum = Vec::with_capacity(cc-1);
-                for b in buckets.into_iter().rev() {
-                    if b.is_zero() == false {
-                        running_sum.push(b)
-                    }
-                    res.extend(running_sum.iter().cloned());
-                }
-
-                G::add_points(vec![res])[0].into_projective()
+                res
             })
             .collect();
 
@@ -146,11 +140,10 @@ impl VariableBaseMSM {
                     running_sum.add_assign_mixed(&b);
                     res += &running_sum;
                 }
-
                 res
             })
             .collect();
-
+        
         // We store the sum for the lowest window.
         let lowest = window_sums.first().unwrap();
 
@@ -192,7 +185,7 @@ mod test {
         acc
     }
 
-    #[test]
+    //#[test]
     fn test_with_bn_382() {
         const SAMPLES: usize = 1 << 10;
 
@@ -240,7 +233,7 @@ mod test {
     {
         let mut length = 1000000;
         let rng = &mut OsRng;
-    
+
         let size_in_bits = <Fp as PrimeField>::size_in_bits();
         let window_size = FixedBaseMSM::get_mul_window_size(length);
         let mut v = FixedBaseMSM::multi_scalar_mul::<G1Projective>
@@ -256,25 +249,22 @@ mod test {
             &(0..length).map(|_| Fp::rand(rng)).collect::<Vec<Fp>>(),
         );
         ProjectiveCurve::batch_normalization(&mut v);
-    
+
         let vector = v.iter().map(|e| e.into_affine()).collect::<Vec<_>>();
-    
+
         println!();
         println!("{}", "*****BENCHMARKING OPTIMISED AFFINE VS SERIAL JACOBIAN MIXED ADDITION*****".blue());
         loop
         {
-            let vectors = (0..10).map(|_| vector[rng.gen_range(0, length/2)..rng.gen_range(length/2, length)].to_vec()).collect::<Vec<_>>();
-    
-            println!("{}{:?}", "Lengths: ".magenta(), vectors.iter().map(|v| v.len()).collect::<Vec<_>>());
-    
+            let mut vectors = (0..1000000/length).map(|_| vector[rng.gen_range(0, length/2)..rng.gen_range(length/2, length)].to_vec()).collect::<Vec<_>>();
+
+            //println!("{}{:?}", "Lengths: ".magenta(), vectors.iter().map(|v| v.len()).collect::<Vec<_>>());
+            println!();
+            println!("{}{:?}", "Length: ".magenta(), length);
+            println!("{}{:?}", "Buckets: ".magenta(), 1000000/length);
+
             let start = Instant::now();
-    
-            let sum1 = AffineCurve::add_points(vectors.clone());
-    
-            let batch = start.elapsed();
-            println!("     {}{:?}", "batch: ".green(), batch);
-            let start = Instant::now();
-    
+
             let sum2 = vectors.iter().map
             (
                 |v|
@@ -287,24 +277,31 @@ mod test {
                     sum.into_affine()
                 }
             ).collect::<Vec<_>>();
-    
+
             let serial = start.elapsed();
             println!("     {}{:?}", "serial: ".green(), serial);
+            let start = Instant::now();
+
+            let sum1 = AffineCurve::add_points(&mut vectors);
+
+            let batch = start.elapsed();
+            println!("     {}{:?}", "batch: ".green(), batch);
             println!("     {}{:?}", "batch/serial: ".green(), batch.as_secs_f32()/serial.as_secs_f32());
             
+            assert_eq!(sum1.iter().eq(sum2.iter()), true);
             assert_eq!(sum1, sum2);
-    
+
             length = length/10;
             if length == 1 {break}
         }
     }
-    
+
     #[test]
-    fn miltiexp()
+    fn multiexp()
     {
         let mut length = 1000000;
         let rng = &mut OsRng;
-    
+
         let size_in_bits = <Fp as PrimeField>::size_in_bits();
         let window_size = FixedBaseMSM::get_mul_window_size(length);
         let mut v = FixedBaseMSM::multi_scalar_mul::<G1Projective>
@@ -320,37 +317,38 @@ mod test {
             &(0..length).map(|_| Fp::rand(rng)).collect::<Vec<Fp>>(),
         );
         ProjectiveCurve::batch_normalization(&mut v);
-    
+
         let bases = v.iter().map(|e| e.into_affine()).collect::<Vec<_>>();
         let scalars = (0..length).map(|_| Fp::rand(rng).into_repr()).collect::<Vec<_>>();
 
         println!();
         println!("{}", "*****BENCHMARKING MULTIEXP WITH OPTIMISED AFFINE VS*****".blue());
         println!("{}", "******MULTIEXP WITH SERIAL JACOBIAN MIXED ADDITION******".blue());
-        length = 10;
+        length = 1000000;
         loop
         {
             let base = bases[0..length].to_vec();
             let scalar = scalars[0..length].to_vec();
 
             println!("{}{:?}", "Length: ".magenta(), length);
-    
+
             let start = Instant::now();
-    
-            let _ = VariableBaseMSM::multi_scalar_mul_affine(&base, &scalar);
-    
+
+            let s1 = VariableBaseMSM::multi_scalar_mul_affine(&base, &scalar);
+
             let batch = start.elapsed();
             println!("     {}{:?}", "batch: ".green(), batch);
             let start = Instant::now();
-    
-            let _ = VariableBaseMSM::multi_scalar_mul(&base, &scalar);
-    
+
+            let s2 = VariableBaseMSM::multi_scalar_mul(&base, &scalar);
+
             let serial = start.elapsed();
             println!("     {}{:?}", "serial: ".green(), serial);
             println!("     {}{:?}", "batch/serial: ".green(), batch.as_secs_f32()/serial.as_secs_f32());
 
-            if length == 1000000 {break}
-            length = length*10;
+            assert_eq!(s1, s2);
+            if length == 1 {break}
+            length = length/10;
         }
     }
 }

--- a/algebra/src/msm/variable_base.rs
+++ b/algebra/src/msm/variable_base.rs
@@ -17,25 +17,22 @@ impl VariableBaseMSM {
             (2.0 / 3.0 * (f64::from(scalars.len() as u32)).log2() + 2.0).ceil() as usize
         };
         let cc = 1 << c;
-        let mut cpus = num_cpus::get();
-        if cpus > cc {cpus = cc}
-        
+
         let num_bits =
             <G::ScalarField as PrimeField>::Params::MODULUS_BITS as usize;
         let fr_one = G::ScalarField::one().into_repr();
 
         let zero = G::zero().into_projective();
         let window_starts: Vec<_> = (0..num_bits).step_by(c).collect();
-        let mut buckets = vec![Vec::<G>::with_capacity(bases.len()/cc); cc];
-        let mut bucketsums = Vec::<G>::with_capacity(cc);
 
         // Each window is of size `c`.
         // We divide up the bits 0..num_bits into windows of size `c`, and
         // in parallel process each such window.
         let window_sums: Vec<_> = window_starts
-            .into_iter()
+            .into_par_iter()
             .map(|w_start| {
                 // We don't need the "zero" bucket, we use 2^c-1 bucket for units
+                let mut buckets = vec![Vec::with_capacity(bases.len()/cc); cc];
                 scalars.iter().zip(bases).filter(|(s, _)| !s.is_zero()).for_each(|(&scalar, base)|  {
                     if scalar == fr_one {
                         // We only process unit scalars once in the first window.
@@ -60,18 +57,11 @@ impl VariableBaseMSM {
                         }
                     }
                 });
-
-                bucketsums.clear();
-                let chunks = buckets.chunks_exact_mut(cc/cpus).collect::<Vec<_>>().
-                    par_iter_mut().map(|c| G::add_points(c)).collect::<Vec<_>>();
-                for mut chunk in chunks
-                {
-                    bucketsums.append(&mut chunk)
-                }
-                let mut res = bucketsums.remove(cc-1).into_projective();
+                let mut buckets = G::add_points(&mut buckets);
+                let mut res = buckets.remove(cc-1).into_projective();
  
                 let mut running_sum = G::Projective::zero();
-                for b in bucketsums.iter().rev() {
+                for b in buckets.iter().rev() {
                     running_sum.add_assign_mixed(b);
                     res += &running_sum;
                 }

--- a/algebra/src/msm/variable_base.rs
+++ b/algebra/src/msm/variable_base.rs
@@ -14,7 +14,7 @@ impl VariableBaseMSM {
         let c = if scalars.len() < 32 {
             3
         } else {
-            (2.0 / 3.0 * (f64::from(scalars.len() as u32)).log2() + 2.0).ceil() as usize
+            (2.0 / 3.0 * (f64::from(scalars.len() as u32)).log2() - 2.0).ceil() as usize
         };
         let cc = 1 << c;
 
@@ -32,7 +32,7 @@ impl VariableBaseMSM {
             .into_par_iter()
             .map(|w_start| {
                 // We don't need the "zero" bucket, we use 2^c-1 bucket for units
-                let mut buckets = vec![Vec::with_capacity(bases.len()/cc); cc];
+                let mut buckets = vec![Vec::with_capacity(bases.len()/cc*2); cc];
                 scalars.iter().zip(bases).filter(|(s, _)| !s.is_zero()).for_each(|(&scalar, base)|  {
                     if scalar == fr_one {
                         // We only process unit scalars once in the first window.

--- a/algebra/src/msm/variable_base.rs
+++ b/algebra/src/msm/variable_base.rs
@@ -1,13 +1,95 @@
 use crate::{
-    AffineCurve, BigInteger, Field, FpParameters, PrimeField,
-    ProjectiveCurve,
+    AffineCurve, ProjectiveCurve, BigInteger, Field, FpParameters, PrimeField,
 };
 use rayon::prelude::*;
 
 pub struct VariableBaseMSM;
 
 impl VariableBaseMSM {
-    fn msm_inner<G: AffineCurve>(
+
+    pub fn multi_scalar_mul_affine<G: AffineCurve>(
+        bases: &[G],
+        scalars: &[<G::ScalarField as PrimeField>::BigInt],
+    ) -> G::Projective {
+        let c = if scalars.len() < 32 {
+            3
+        } else {
+            ((f64::from(scalars.len() as u32)).log2() / 3.0 + 1.0).floor() as usize
+        };
+        let cc = 1 << c;
+
+        let num_bits =
+            <G::ScalarField as PrimeField>::Params::MODULUS_BITS as usize;
+        let fr_one = G::ScalarField::one().into_repr();
+
+        let zero = G::zero().into_projective();
+        let window_starts: Vec<_> = (0..num_bits).step_by(c).collect();
+
+        // Each window is of size `c`.
+        // We divide up the bits 0..num_bits into windows of size `c`, and
+        // in parallel process each such window.
+        let window_sums: Vec<_> = window_starts
+            .into_par_iter()
+            .map(|w_start| {
+                // We don't need the "zero" bucket, we use 2^c-1 bucket for units
+                let mut buckets = vec![Vec::with_capacity(bases.len()*c/cc); cc];
+                scalars.iter().zip(bases).filter(|(s, _)| !s.is_zero()).for_each(|(&scalar, base)|  {
+                    if scalar == fr_one {
+                        // We only process unit scalars once in the first window.
+                        if w_start == 0 && base.is_zero() == false {
+                            buckets[cc-1].push(*base);
+                        }
+                    } else {
+                        let mut scalar = scalar;
+
+                        // We right-shift by w_start, thus getting rid of the
+                        // lower bits.
+                        scalar.divn(w_start as u32);
+
+                        // We mod the remaining bits by the window size.
+                        let scalar = scalar.as_ref()[0] % (1 << c);
+
+                        // If the scalar is non-zero, we update the corresponding
+                        // bucket.
+                        // (Recall that `buckets` doesn't have a zero bucket.)
+                        if scalar != 0 && base.is_zero() == false {
+                            buckets[(scalar - 1) as usize].push(*base);
+                        }
+                    }
+                });
+                let mut buckets = G::add_points(buckets);
+                let mut res = Vec::with_capacity(cc*(cc-1)/2+1);
+                if buckets[cc-1].is_zero() == false {
+                    res.push(buckets[cc-1])
+                }
+                buckets.truncate(cc-1);
+
+                let mut running_sum = Vec::with_capacity(cc-1);
+                for b in buckets.into_iter().rev() {
+                    if b.is_zero() == false {
+                        running_sum.push(b)
+                    }
+                    res.extend(running_sum.iter().cloned());
+                }
+
+                G::add_points(vec![res])[0].into_projective()
+            })
+            .collect();
+
+        // We store the sum for the lowest window.
+        let lowest = window_sums.first().unwrap();
+
+        // We're traversing windows from high to low.
+        window_sums[1..].iter().rev().fold(zero, |mut total, sum_i| {
+            total += sum_i;
+            for _ in 0..c {
+                total.double_in_place();
+            }
+            total
+        }) + lowest
+    }
+
+    pub fn multi_scalar_mul<G: AffineCurve>(
         bases: &[G],
         scalars: &[<G::ScalarField as PrimeField>::BigInt],
     ) -> G::Projective {
@@ -81,23 +163,22 @@ impl VariableBaseMSM {
             total
         }) + lowest
     }
-
-    pub fn multi_scalar_mul<G: AffineCurve>(
-        bases: &[G],
-        scalars: &[<G::ScalarField as PrimeField>::BigInt],
-    ) -> G::Projective {
-        Self::msm_inner(bases, scalars)
-    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::curves::bls12_381::G1Projective;
-    use crate::fields::bls12_381::Fr;
+    use crate::curves::bn_382::G1Projective;
+    use crate::fields::bn_382::Fp;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
     use crate::UniformRand;
+    use crate::FixedBaseMSM;
+    use colored::Colorize;
+    use std::time::Instant;
+    use rand::Rng;
+    use rand_core::OsRng;
+        
 
     fn naive_var_base_msm<G: AffineCurve>(
         bases: &[G],
@@ -112,13 +193,13 @@ mod test {
     }
 
     #[test]
-    fn test_with_bls12() {
+    fn test_with_bn_382() {
         const SAMPLES: usize = 1 << 10;
 
         let mut rng = XorShiftRng::seed_from_u64(234872845u64);
 
         let v = (0..SAMPLES)
-            .map(|_| Fr::rand(&mut rng).into_repr())
+            .map(|_| Fp::rand(&mut rng).into_repr())
             .collect::<Vec<_>>();
         let g = (0..SAMPLES)
             .map(|_| G1Projective::rand(&mut rng).into_affine())
@@ -126,27 +207,150 @@ mod test {
 
         let naive = naive_var_base_msm(g.as_slice(), v.as_slice());
         let fast = VariableBaseMSM::multi_scalar_mul(g.as_slice(), v.as_slice());
+        let affine = VariableBaseMSM::multi_scalar_mul_affine(g.as_slice(), v.as_slice());
 
-        assert_eq!(naive.into_affine(), fast.into_affine());
+        assert_eq!(naive, fast);
+        assert_eq!(naive, affine)
     }
 
 
     #[test]
-    fn test_with_bls12_unequal_numbers() {
+    fn test_with_bn_382_unequal_numbers() {
         const SAMPLES: usize = 1 << 10;
 
         let mut rng = XorShiftRng::seed_from_u64(234872845u64);
 
         let v = (0..SAMPLES-1)
-            .map(|_| Fr::rand(&mut rng).into_repr())
+            .map(|_| Fp::rand(&mut rng).into_repr())
             .collect::<Vec<_>>();
         let g = (0..SAMPLES)
             .map(|_| G1Projective::rand(&mut rng).into_affine())
             .collect::<Vec<_>>();
 
         let naive = naive_var_base_msm(g.as_slice(), v.as_slice());
-        let fast = VariableBaseMSM::multi_scalar_mul(g.as_slice(), v.as_slice());
+        let fast = VariableBaseMSM::multi_scalar_mul_affine(g.as_slice(), v.as_slice());
+        let affine = VariableBaseMSM::multi_scalar_mul_affine(g.as_slice(), v.as_slice());
 
-        assert_eq!(naive.into_affine(), fast.into_affine());
+        assert_eq!(naive, fast);
+        assert_eq!(naive, affine)
+    }
+
+    #[test]
+    fn batch_addition()
+    {
+        let mut length = 1000000;
+        let rng = &mut OsRng;
+    
+        let size_in_bits = <Fp as PrimeField>::size_in_bits();
+        let window_size = FixedBaseMSM::get_mul_window_size(length);
+        let mut v = FixedBaseMSM::multi_scalar_mul::<G1Projective>
+        (
+            size_in_bits,
+            window_size,
+            &FixedBaseMSM::get_window_table
+            (
+                size_in_bits,
+                window_size,
+                G1Projective::prime_subgroup_generator()
+            ),
+            &(0..length).map(|_| Fp::rand(rng)).collect::<Vec<Fp>>(),
+        );
+        ProjectiveCurve::batch_normalization(&mut v);
+    
+        let vector = v.iter().map(|e| e.into_affine()).collect::<Vec<_>>();
+    
+        println!();
+        println!("{}", "*****BENCHMARKING OPTIMISED AFFINE VS SERIAL JACOBIAN MIXED ADDITION*****".blue());
+        loop
+        {
+            let vectors = (0..10).map(|_| vector[rng.gen_range(0, length/2)..rng.gen_range(length/2, length)].to_vec()).collect::<Vec<_>>();
+    
+            println!("{}{:?}", "Lengths: ".magenta(), vectors.iter().map(|v| v.len()).collect::<Vec<_>>());
+    
+            let start = Instant::now();
+    
+            let sum1 = AffineCurve::add_points(vectors.clone());
+    
+            let batch = start.elapsed();
+            println!("     {}{:?}", "batch: ".green(), batch);
+            let start = Instant::now();
+    
+            let sum2 = vectors.iter().map
+            (
+                |v|
+                {
+                    let mut sum = G1Projective::zero();
+                    for point in v.iter()
+                    {
+                        sum.add_assign_mixed(point);
+                    }
+                    sum.into_affine()
+                }
+            ).collect::<Vec<_>>();
+    
+            let serial = start.elapsed();
+            println!("     {}{:?}", "serial: ".green(), serial);
+            println!("     {}{:?}", "batch/serial: ".green(), batch.as_secs_f32()/serial.as_secs_f32());
+            
+            assert_eq!(sum1, sum2);
+    
+            length = length/10;
+            if length == 1 {break}
+        }
+    }
+    
+    #[test]
+    fn miltiexp()
+    {
+        let mut length = 1000000;
+        let rng = &mut OsRng;
+    
+        let size_in_bits = <Fp as PrimeField>::size_in_bits();
+        let window_size = FixedBaseMSM::get_mul_window_size(length);
+        let mut v = FixedBaseMSM::multi_scalar_mul::<G1Projective>
+        (
+            size_in_bits,
+            window_size,
+            &FixedBaseMSM::get_window_table
+            (
+                size_in_bits,
+                window_size,
+                G1Projective::prime_subgroup_generator()
+            ),
+            &(0..length).map(|_| Fp::rand(rng)).collect::<Vec<Fp>>(),
+        );
+        ProjectiveCurve::batch_normalization(&mut v);
+    
+        let bases = v.iter().map(|e| e.into_affine()).collect::<Vec<_>>();
+        let scalars = (0..length).map(|_| Fp::rand(rng).into_repr()).collect::<Vec<_>>();
+
+        println!();
+        println!("{}", "*****BENCHMARKING MULTIEXP WITH OPTIMISED AFFINE VS*****".blue());
+        println!("{}", "******MULTIEXP WITH SERIAL JACOBIAN MIXED ADDITION******".blue());
+        length = 10;
+        loop
+        {
+            let base = bases[0..length].to_vec();
+            let scalar = scalars[0..length].to_vec();
+
+            println!("{}{:?}", "Length: ".magenta(), length);
+    
+            let start = Instant::now();
+    
+            let _ = VariableBaseMSM::multi_scalar_mul_affine(&base, &scalar);
+    
+            let batch = start.elapsed();
+            println!("     {}{:?}", "batch: ".green(), batch);
+            let start = Instant::now();
+    
+            let _ = VariableBaseMSM::multi_scalar_mul(&base, &scalar);
+    
+            let serial = start.elapsed();
+            println!("     {}{:?}", "serial: ".green(), serial);
+            println!("     {}{:?}", "batch/serial: ".green(), batch.as_secs_f32()/serial.as_secs_f32());
+
+            if length == 1000000 {break}
+            length = length*10;
+        }
     }
 }


### PR DESCRIPTION
This pull request implements:

1.Batched Affine point addition. This functionality allows the optimized addition of points in an array of vectors of group elements such that elements of each vector of the array are all summed up into a single group element. Thus, the array of vectors of group elements is summed up into the array of group elements which are the sums of elements of the corresponding vectors. The Affine addition field element inversions are all batched across the complete array of vectors in rounds yielding the "logarithmic" (with respect to the number of resulting inversions) performance.
2. Implementation of the Pippenger multiexponentiation algorithm with the use of the optimized Affine addition.


Use:
     to exercise the implemented functionality, run the tests and benchmarks as this:
     cargo test --release -- --nocapture --test-threads 1 variable_base


Observations with the current implementation:

1. Batched Affine point addition algorithm provides on average, as evidenced by the attached benchmark screenshot, ~35% performance improvement over the use of the serial mixed Jacobian addition.

2. Use of the optimized Affine addition for the multiexponentiation Pippernger algorithm proves, as evidenced by the attached benchmark screenshot, to produce a negative performance effect on the multiexponentiation functionality. The positive effects of the optimised Affine addition are negated by the use of memory allocations and memory IO. Performance improvement of the optimized Affine addition relies on the array of vectors of group elements to be in advance prepared for the summation. Pippenger (in this form), on the other hand, has to additionally deal with the allocation of the arrays of vectors (in parallel under multithreading) and the movement of elements into its vectors. These memory allocations and memory IO produce the negative performance effect. Thanslating to the Pippenger lexicon, the arrays of vectors correspond to the Windows whereas the vectors themselves correspond to Buckets.
![Screenshot from 2020-04-26 13-12-29](https://user-images.githubusercontent.com/59975641/80314478-b695df00-87bf-11ea-84a9-01261e358d24.png)

![Affine-batched-addition-performance](https://user-images.githubusercontent.com/59975641/80314592-72570e80-87c0-11ea-9642-3a2e4424b845.png)
![multiexp-with-affine-bathed-addition-performance](https://user-images.githubusercontent.com/59975641/80314595-771bc280-87c0-11ea-9639-a4a47777a9d1.png)


