### PR TITLE
Various type fixes for plonk bindings

### DIFF
--- a/snarky-bn382/bindings_gen/snarky_bn382_ctypes_stubs.ml
+++ b/snarky-bn382/bindings_gen/snarky_bn382_ctypes_stubs.ml
@@ -9,8 +9,5 @@ let () =
     Format.formatter_of_out_channel
       (open_out "snarky_bn382_generated_stubs.ml")
   in
-  Format.fprintf fmt "%s@." {ocaml|
-[@@@warning "-11"]
-|ocaml} ;
   Cstubs_applicative.write_ml ~prefix:"snarky_bn382" fmt
     (module Snarky_bn382_bindings.Full)

--- a/snarky-bn382/caml/snarky_bn382_bindings.ml
+++ b/snarky-bn382/caml/snarky_bn382_bindings.ml
@@ -1523,7 +1523,10 @@ struct
 
   let t_comm = f "t_comm" PolyComm.typ PolyComm.add_finalizer
 
-  let proof_comm = f "proof" OpeningProof.typ OpeningProof.add_finalizer
+  let proof = f "proof" OpeningProof.typ OpeningProof.add_finalizer
+
+  let evals_nocopy =
+    f "evals_nocopy" Evaluations.Pair.typ Evaluations.Pair.add_finalizer
 end
 
 module Pairing_oracles

--- a/snarky-bn382/caml/snarky_bn382_bindings.ml
+++ b/snarky-bn382/caml/snarky_bn382_bindings.ml
@@ -2476,10 +2476,10 @@ module Full (F : Cstubs_applicative.Foreign_applicative) = struct
         (Field_poly_comm)
 
     module Field_oracles =
-      Dlog_oracles
+      Dlog_plonk_oracles
         (F)
         (struct
-          let prefix = with_prefix (prefix "oracles")
+          let prefix = with_prefix (P.prefix "oracles")
         end)
         (Field)
         (Field_verifier_index)

--- a/snarky-bn382/caml/snarky_bn382_bindings.ml
+++ b/snarky-bn382/caml/snarky_bn382_bindings.ml
@@ -1482,7 +1482,7 @@ struct
       foreign (prefix "make")
         ( ScalarFieldVector.typ @-> PolyComm.typ @-> PolyComm.typ
         @-> PolyComm.typ @-> PolyComm.typ @-> PolyComm.typ
-        @-> AffineCurve.Pair.Vector.typ @-> PolyComm.typ @-> PolyComm.typ
+        @-> AffineCurve.Pair.Vector.typ @-> ScalarField.typ @-> ScalarField.typ
         @-> AffineCurve.typ @-> AffineCurve.typ @-> Evaluations.typ
         @-> Evaluations.typ @-> returning typ )
     and add_finalizer = add_finalizer in

--- a/snarky-bn382/caml/snarky_bn382_bindings.ml
+++ b/snarky-bn382/caml/snarky_bn382_bindings.ml
@@ -1375,7 +1375,9 @@ module Dlog_plonk_proof
                     and type 'a return := 'a F.return)
     (Index : Type)
     (VerifierIndex : Type)
-    (ScalarFieldVector : Type)
+    (ScalarFieldVector : Type_with_finalizer
+                         with type 'a result := 'a F.result
+                          and type 'a return := 'a F.return)
     (FieldVectorPair : Type)
     (OpeningProof : Type_with_finalizer
                     with type 'a result := 'a F.result
@@ -1434,8 +1436,8 @@ struct
     include T
 
     let f s =
-      let%map f = foreign (prefix s) (typ @-> returning ScalarField.typ)
-      and add_finalizer = ScalarField.add_finalizer in
+      let%map f = foreign (prefix s) (typ @-> returning ScalarFieldVector.typ)
+      and add_finalizer = ScalarFieldVector.add_finalizer in
       fun t -> add_finalizer (f t)
 
     let sigma1 = f "sigma1"
@@ -1465,9 +1467,11 @@ struct
     let make =
       let%map make =
         foreign (prefix "make")
-          ( ScalarField.typ @-> ScalarField.typ @-> ScalarField.typ
-          @-> ScalarField.typ @-> ScalarField.typ @-> ScalarField.typ
-          @-> ScalarField.typ @-> ScalarField.typ @-> returning typ )
+          ( ScalarFieldVector.typ @-> ScalarFieldVector.typ
+          @-> ScalarFieldVector.typ @-> ScalarFieldVector.typ
+          @-> ScalarFieldVector.typ @-> ScalarFieldVector.typ
+          @-> ScalarFieldVector.typ @-> ScalarFieldVector.typ @-> returning typ
+          )
       and add_finalizer = add_finalizer in
       fun ~l ~r ~o ~z ~t ~f ~sigma1 ~sigma2 ->
         add_finalizer (make l r o z t f sigma1 sigma2)

--- a/snarky-bn382/src/tweedledee_plonk.rs
+++ b/snarky-bn382/src/tweedledee_plonk.rs
@@ -634,80 +634,80 @@ pub extern "C" fn zexe_tweedle_plonk_fp_opening_proof_delta(
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_l(
-    e: *const DlogProofEvaluations<Fp>,
-) -> *const Fp {
+    e: *const DlogProofEvaluations<Vec<Fp>>,
+) -> *const Vec<Fp> {
     let x = (unsafe { &(*e).l }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_r(
-    e: *const DlogProofEvaluations<Fp>,
-) -> *const Fp {
+    e: *const DlogProofEvaluations<Vec<Fp>>,
+) -> *const Vec<Fp> {
     let x = (unsafe { &(*e).r }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_o(
-    e: *const DlogProofEvaluations<Fp>,
-) -> *const Fp {
+    e: *const DlogProofEvaluations<Vec<Fp>>,
+) -> *const Vec<Fp> {
     let x = (unsafe { &(*e).o }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_z(
-    e: *const DlogProofEvaluations<Fp>,
-) -> *const Fp {
+    e: *const DlogProofEvaluations<Vec<Fp>>,
+) -> *const Vec<Fp> {
     let x = (unsafe { &(*e).z }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_t(
-    e: *const DlogProofEvaluations<Fp>,
-) -> *const Fp {
+    e: *const DlogProofEvaluations<Vec<Fp>>,
+) -> *const Vec<Fp> {
     let x = (unsafe { &(*e).t }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_f(
-    e: *const DlogProofEvaluations<Fp>,
-) -> *const Fp {
+    e: *const DlogProofEvaluations<Vec<Fp>>,
+) -> *const Vec<Fp> {
     let x = (unsafe { &(*e).f }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_sigma1(
-    e: *const DlogProofEvaluations<Fp>,
-) -> *const Fp {
+    e: *const DlogProofEvaluations<Vec<Fp>>,
+) -> *const Vec<Fp> {
     let x = (unsafe { &(*e).sigma1 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_sigma2(
-    e: *const DlogProofEvaluations<Fp>,
-) -> *const Fp {
+    e: *const DlogProofEvaluations<Vec<Fp>>,
+) -> *const Vec<Fp> {
     let x = (unsafe { &(*e).sigma2 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_make(
-    l: *const Fp,
-    r: *const Fp,
-    o: *const Fp,
-    z: *const Fp,
-    t: *const Fp,
-    f: *const Fp,
-    sigma1: *const Fp,
-    sigma2: *const Fp,
-) -> *const DlogProofEvaluations<Fp> {
-    let res: DlogProofEvaluations<Fp> = DlogProofEvaluations {
+    l: *const Vec<Fp>,
+    r: *const Vec<Fp>,
+    o: *const Vec<Fp>,
+    z: *const Vec<Fp>,
+    t: *const Vec<Fp>,
+    f: *const Vec<Fp>,
+    sigma1: *const Vec<Fp>,
+    sigma2: *const Vec<Fp>,
+) -> *const DlogProofEvaluations<Vec<Fp>> {
+    let res: DlogProofEvaluations<Vec<Fp>> = DlogProofEvaluations {
         l: (unsafe { &*l }).clone(),
         r: (unsafe { &*r }).clone(),
         o: (unsafe { &*o }).clone(),
@@ -722,28 +722,28 @@ pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_make(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_delete(x: *mut DlogProofEvaluations<Fp>) {
+pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_delete(x: *mut DlogProofEvaluations<Vec<Fp>>) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_pair_0(
-    e: *const [DlogProofEvaluations<Fp>; 2],
-) -> *const DlogProofEvaluations<Fp> {
+    e: *const [DlogProofEvaluations<Vec<Fp>>; 2],
+) -> *const DlogProofEvaluations<Vec<Fp>> {
     let x = (unsafe { &(*e)[0] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_pair_1(
-    e: *const [DlogProofEvaluations<Fp>; 2],
-) -> *const DlogProofEvaluations<Fp> {
+    e: *const [DlogProofEvaluations<Vec<Fp>>; 2],
+) -> *const DlogProofEvaluations<Vec<Fp>> {
     let x = (unsafe { &(*e)[1] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_pair_delete(x: *mut [DlogProofEvaluations<Fp>; 2]) {
+pub extern "C" fn zexe_tweedle_plonk_fp_proof_evaluations_pair_delete(x: *mut [DlogProofEvaluations<Vec<Fp>>; 2]) {
     let _box = unsafe { Box::from_raw(x) };
 }
 

--- a/snarky-bn382/src/tweedledum_plonk.rs
+++ b/snarky-bn382/src/tweedledum_plonk.rs
@@ -635,80 +635,80 @@ pub extern "C" fn zexe_tweedle_plonk_fq_opening_proof_delta(
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_l(
-    e: *const DlogProofEvaluations<Fq>,
-) -> *const Fq {
+    e: *const DlogProofEvaluations<Vec<Fq>>,
+) -> *const Vec<Fq> {
     let x = (unsafe { &(*e).l }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_r(
-    e: *const DlogProofEvaluations<Fq>,
-) -> *const Fq {
+    e: *const DlogProofEvaluations<Vec<Fq>>,
+) -> *const Vec<Fq> {
     let x = (unsafe { &(*e).r }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_o(
-    e: *const DlogProofEvaluations<Fq>,
-) -> *const Fq {
+    e: *const DlogProofEvaluations<Vec<Fq>>,
+) -> *const Vec<Fq> {
     let x = (unsafe { &(*e).o }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_z(
-    e: *const DlogProofEvaluations<Fq>,
-) -> *const Fq {
+    e: *const DlogProofEvaluations<Vec<Fq>>,
+) -> *const Vec<Fq> {
     let x = (unsafe { &(*e).z }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_t(
-    e: *const DlogProofEvaluations<Fq>,
-) -> *const Fq {
+    e: *const DlogProofEvaluations<Vec<Fq>>,
+) -> *const Vec<Fq> {
     let x = (unsafe { &(*e).t }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_f(
-    e: *const DlogProofEvaluations<Fq>,
-) -> *const Fq {
+    e: *const DlogProofEvaluations<Vec<Fq>>,
+) -> *const Vec<Fq> {
     let x = (unsafe { &(*e).f }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_sigma1(
-    e: *const DlogProofEvaluations<Fq>,
-) -> *const Fq {
+    e: *const DlogProofEvaluations<Vec<Fq>>,
+) -> *const Vec<Fq> {
     let x = (unsafe { &(*e).sigma1 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_sigma2(
-    e: *const DlogProofEvaluations<Fq>,
-) -> *const Fq {
+    e: *const DlogProofEvaluations<Vec<Fq>>,
+) -> *const Vec<Fq> {
     let x = (unsafe { &(*e).sigma2 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_make(
-    l: *const Fq,
-    r: *const Fq,
-    o: *const Fq,
-    z: *const Fq,
-    t: *const Fq,
-    f: *const Fq,
-    sigma1: *const Fq,
-    sigma2: *const Fq,
-) -> *const DlogProofEvaluations<Fq> {
-    let res: DlogProofEvaluations<Fq> = DlogProofEvaluations {
+    l: *const Vec<Fq>,
+    r: *const Vec<Fq>,
+    o: *const Vec<Fq>,
+    z: *const Vec<Fq>,
+    t: *const Vec<Fq>,
+    f: *const Vec<Fq>,
+    sigma1: *const Vec<Fq>,
+    sigma2: *const Vec<Fq>,
+) -> *const DlogProofEvaluations<Vec<Fq>> {
+    let res: DlogProofEvaluations<Vec<Fq>> = DlogProofEvaluations {
         l: (unsafe { &*l }).clone(),
         r: (unsafe { &*r }).clone(),
         o: (unsafe { &*o }).clone(),
@@ -723,28 +723,28 @@ pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_make(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_delete(x: *mut DlogProofEvaluations<Fq>) {
+pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_delete(x: *mut DlogProofEvaluations<Vec<Fq>>) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_pair_0(
-    e: *const [DlogProofEvaluations<Fq>; 2],
-) -> *const DlogProofEvaluations<Fq> {
+    e: *const [DlogProofEvaluations<Vec<Fq>>; 2],
+) -> *const DlogProofEvaluations<Vec<Fq>> {
     let x = (unsafe { &(*e)[0] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_pair_1(
-    e: *const [DlogProofEvaluations<Fq>; 2],
-) -> *const DlogProofEvaluations<Fq> {
+    e: *const [DlogProofEvaluations<Vec<Fq>>; 2],
+) -> *const DlogProofEvaluations<Vec<Fq>> {
     let x = (unsafe { &(*e)[1] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_pair_delete(x: *mut [DlogProofEvaluations<Fq>; 2]) {
+pub extern "C" fn zexe_tweedle_plonk_fq_proof_evaluations_pair_delete(x: *mut [DlogProofEvaluations<Vec<Fq>>; 2]) {
     let _box = unsafe { Box::from_raw(x) };
 }
 


### PR DESCRIPTION
This fixes a segfault in the pickles bindings in coda, where we were interpreting a `Vec<Fp>` as an `Fp`.