### PR TITLE
Reformat using `cargo fmt`

### DIFF
--- a/snarky-bn382/src/bn382_dlog.rs
+++ b/snarky-bn382/src/bn382_dlog.rs
@@ -1,55 +1,56 @@
 use crate::common::*;
 use algebra::{
-    ToBytes, FromBytes, One, Zero,
-    biginteger::{BigInteger384},
+    biginteger::BigInteger384,
     bn_382::{
-        g::{Affine as GAffine, Projective as GProjective},
-        g::Bn_382GParameters,
-        fp::{Fp, },
+        fp::Fp,
         fq::{Fq, FqParameters as Fq_params},
+        g::Bn_382GParameters,
+        g::{Affine as GAffine, Projective as GProjective},
     },
-    curves::{
-        AffineCurve, ProjectiveCurve,
-    },
-    fields::{
-        Field, FpParameters, PrimeField, SquareRootField,
-    },
-    UniformRand,
+    curves::{AffineCurve, ProjectiveCurve},
+    fields::{Field, FpParameters, PrimeField, SquareRootField},
+    FromBytes, One, ToBytes, UniformRand, Zero,
 };
 
 use marlin_circuits::domains::EvaluationDomains;
 
-use ff_fft::{Evaluations, DensePolynomial, EvaluationDomain, Radix2EvaluationDomain as Domain};
+use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as Domain};
 
 use oracle::{
     self,
+    poseidon::MarlinSpongeConstants as SC,
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
-    poseidon::{MarlinSpongeConstants as SC},
 };
 
 use rand::rngs::StdRng;
 use rand_core;
 
-use std::os::raw::c_char;
+use groupmap::GroupMap;
 use std::ffi::CStr;
 use std::fs::File;
-use std::io::{Read, Result as IoResult, Write, BufReader, BufWriter};
-use groupmap::GroupMap;
+use std::io::{BufReader, BufWriter, Read, Result as IoResult, Write};
+use std::os::raw::c_char;
 
-use marlin_protocol_dlog::index::{
-    Index as DlogIndex, SRSSpec, SRSValue, VerifierIndex as DlogVerifierIndex,
-};
 use commitment_dlog::{
     commitment::{b_poly_coefficients, product, CommitmentCurve, OpeningProof, PolyComm},
     srs::SRS,
 };
-use marlin_protocol_dlog::prover::{ProofEvaluations as DlogProofEvaluations, ProverProof as DlogProof};
+use marlin_protocol_dlog::index::{
+    Index as DlogIndex, SRSSpec, SRSValue, VerifierIndex as DlogVerifierIndex,
+};
+use marlin_protocol_dlog::prover::{
+    ProofEvaluations as DlogProofEvaluations, ProverProof as DlogProof,
+};
 
 use algebra::bn_382::g::Affine;
 
 // Fq URS stubs
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_urs_create(depth: usize, public: usize, size: usize) -> *const SRS<GAffine> {
+pub extern "C" fn zexe_bn382_fq_urs_create(
+    depth: usize,
+    public: usize,
+    size: usize,
+) -> *const SRS<GAffine> {
     Box::into_raw(Box::new(SRS::create(depth, public, size)))
 }
 
@@ -70,7 +71,9 @@ pub extern "C" fn zexe_bn382_fq_urs_write(urs: *mut SRS<GAffine>, path: *mut c_c
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_urs_read(path: *mut c_char) -> *const SRS<GAffine> {
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let file = BufReader::new(File::open(path).unwrap());
     let res = SRS::<GAffine>::read(file).unwrap();
     return Box::into_raw(Box::new(res));
@@ -78,14 +81,16 @@ pub extern "C" fn zexe_bn382_fq_urs_read(path: *mut c_char) -> *const SRS<GAffin
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_urs_lagrange_commitment(
-    urs : *const SRS<GAffine>,
-    domain_size : usize,
-    i: usize)
--> *const PolyComm<GAffine> {
+    urs: *const SRS<GAffine>,
+    domain_size: usize,
+    i: usize,
+) -> *const PolyComm<GAffine> {
     let urs = unsafe { &*urs };
     let x_domain = EvaluationDomain::<Fq>::new(domain_size).unwrap();
 
-    let evals = (0..domain_size).map(|j| if i == j { Fq::one() } else { Fq::zero() }).collect();
+    let evals = (0..domain_size)
+        .map(|j| if i == j { Fq::one() } else { Fq::zero() })
+        .collect();
     let p = Evaluations::<Fq>::from_vec_and_domain(evals, x_domain).interpolate();
     let res = urs.commit(&p, None);
 
@@ -94,10 +99,10 @@ pub extern "C" fn zexe_bn382_fq_urs_lagrange_commitment(
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_urs_commit_evaluations(
-    urs : *const SRS<GAffine>,
-    domain_size : usize,
-    evals : *const Vec<Fq>)
--> *const PolyComm<GAffine> {
+    urs: *const SRS<GAffine>,
+    domain_size: usize,
+    evals: *const Vec<Fq>,
+) -> *const PolyComm<GAffine> {
     let urs = unsafe { &*urs };
     let x_domain = EvaluationDomain::<Fq>::new(domain_size).unwrap();
 
@@ -110,14 +115,14 @@ pub extern "C" fn zexe_bn382_fq_urs_commit_evaluations(
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_urs_b_poly_commitment(
-    urs : *const SRS<GAffine>,
-    chals : *const Vec<Fq>)
--> *const PolyComm<GAffine> {
-    let chals = unsafe { & *chals };
+    urs: *const SRS<GAffine>,
+    chals: *const Vec<Fq>,
+) -> *const PolyComm<GAffine> {
+    let chals = unsafe { &*chals };
     let urs = unsafe { &*urs };
 
     let s0 = product(chals.iter().map(|x| *x)).inverse().unwrap();
-    let chal_squareds : Vec<Fq> = chals.iter().map(|x| x.square()).collect();
+    let chal_squareds: Vec<Fq> = chals.iter().map(|x| x.square()).collect();
     let coeffs = b_poly_coefficients(s0, &chal_squareds);
     let p = DensePolynomial::<Fq>::from_coefficients_vec(coeffs);
     let g = urs.commit(&p, None);
@@ -126,9 +131,7 @@ pub extern "C" fn zexe_bn382_fq_urs_b_poly_commitment(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_urs_h(
-    urs : *const SRS<GAffine>, )
--> *const GAffine {
+pub extern "C" fn zexe_bn382_fq_urs_h(urs: *const SRS<GAffine>) -> *const GAffine {
     let urs = unsafe { &*urs };
     let res = urs.h;
     Box::into_raw(Box::new(res))
@@ -136,13 +139,13 @@ pub extern "C" fn zexe_bn382_fq_urs_h(
 
 // Fq index stubs
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_index_domain_h_size<'a>(i : *const DlogIndex<'a, GAffine>) -> usize {
-    (unsafe { & *i }).domains.h.size()
+pub extern "C" fn zexe_bn382_fq_index_domain_h_size<'a>(i: *const DlogIndex<'a, GAffine>) -> usize {
+    (unsafe { &*i }).domains.h.size()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_index_domain_k_size<'a>(i : *const DlogIndex<'a, GAffine>) -> usize {
-    (unsafe { & *i }).domains.k.size()
+pub extern "C" fn zexe_bn382_fq_index_domain_k_size<'a>(i: *const DlogIndex<'a, GAffine>) -> usize {
+    (unsafe { &*i }).domains.k.size()
 }
 
 #[no_mangle]
@@ -152,7 +155,7 @@ pub extern "C" fn zexe_bn382_fq_index_create<'a>(
     c: *mut Vec<(Vec<usize>, Vec<Fq>)>,
     vars: usize,
     public_inputs: usize,
-    srs : *mut SRS<GAffine>
+    srs: *mut SRS<GAffine>,
 ) -> *mut DlogIndex<'a, GAffine> {
     assert!(public_inputs > 0);
 
@@ -163,7 +166,11 @@ pub extern "C" fn zexe_bn382_fq_index_create<'a>(
 
     let num_constraints = a.len();
 
-    let m = if num_constraints > vars { num_constraints } else { vars };
+    let m = if num_constraints > vars {
+        num_constraints
+    } else {
+        vars
+    };
 
     let h_group_size = Domain::<Fq>::compute_size_of_domain(m).unwrap();
     let h_to_x_ratio = {
@@ -192,33 +199,30 @@ pub extern "C" fn zexe_bn382_fq_index_delete(x: *mut DlogIndex<GAffine>) {
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_index_nonzero_entries(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_bn382_fq_index_nonzero_entries(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
-    index.compiled.iter().map(|x| x.constraints.nnz()).max().unwrap()
+    index
+        .compiled
+        .iter()
+        .map(|x| x.constraints.nnz())
+        .max()
+        .unwrap()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_index_max_degree(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_bn382_fq_index_max_degree(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
     index.srs.get_ref().max_degree()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_index_num_variables(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_bn382_fq_index_num_variables(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
     index.compiled[0].constraints.shape().0
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_index_public_inputs(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_bn382_fq_index_public_inputs(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
     index.public_inputs
 }
@@ -240,22 +244,24 @@ pub extern "C" fn zexe_bn382_fq_index_write<'a>(
         write_dense_polynomial(&c.row, &mut w)?;
         write_dense_polynomial(&c.col, &mut w)?;
         write_dense_polynomial(&c.val, &mut w)?;
-        write_evaluations(& c.row_eval_k, &mut w)?;
-        write_evaluations(& c.col_eval_k, &mut w)?;
-        write_evaluations(& c.val_eval_k, &mut w)?;
-        write_evaluations(& c.row_eval_b, &mut w)?;
-        write_evaluations(& c.col_eval_b, &mut w)?;
-        write_evaluations(& c.val_eval_b, &mut w)?;
-        write_evaluations(& c.rc_eval_b , &mut w)?;
+        write_evaluations(&c.row_eval_k, &mut w)?;
+        write_evaluations(&c.col_eval_k, &mut w)?;
+        write_evaluations(&c.val_eval_k, &mut w)?;
+        write_evaluations(&c.row_eval_b, &mut w)?;
+        write_evaluations(&c.col_eval_b, &mut w)?;
+        write_evaluations(&c.val_eval_b, &mut w)?;
+        write_evaluations(&c.rc_eval_b, &mut w)?;
         Ok(())
     }
 
-    let index = unsafe { & *index };
+    let index = unsafe { &*index };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut w = BufWriter::new(File::create(path).unwrap());
 
-    let t : IoResult<()> = (|| {
+    let t: IoResult<()> = (|| {
         write_evaluation_domains(&index.domains, &mut w)?;
 
         for c in index.compiled.iter() {
@@ -270,7 +276,7 @@ pub extern "C" fn zexe_bn382_fq_index_write<'a>(
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_index_read<'a>(
-    srs : *const SRS<GAffine>,
+    srs: *const SRS<GAffine>,
     a: *const Vec<(Vec<usize>, Vec<Fq>)>,
     b: *const Vec<(Vec<usize>, Vec<Fq>)>,
     c: *const Vec<(Vec<usize>, Vec<Fq>)>,
@@ -293,8 +299,8 @@ pub extern "C" fn zexe_bn382_fq_index_read<'a>(
         let col_comm = read_poly_comm(&mut r)?;
         let row_comm = read_poly_comm(&mut r)?;
         let val_comm = read_poly_comm(&mut r)?;
-        let rc_comm =  read_poly_comm(&mut r)?;
-        let rc  = read_dense_polynomial(&mut r)?;
+        let rc_comm = read_poly_comm(&mut r)?;
+        let rc = read_dense_polynomial(&mut r)?;
         let row = read_dense_polynomial(&mut r)?;
         let col = read_dense_polynomial(&mut r)?;
         let val = read_dense_polynomial(&mut r)?;
@@ -304,33 +310,36 @@ pub extern "C" fn zexe_bn382_fq_index_read<'a>(
         let row_eval_b = read_evaluations(&mut r)?;
         let col_eval_b = read_evaluations(&mut r)?;
         let val_eval_b = read_evaluations(&mut r)?;
-        let rc_eval_b  = read_evaluations(&mut r)?;
+        let rc_eval_b = read_evaluations(&mut r)?;
 
         Ok(marlin_protocol_dlog::compiled::Compiled {
             constraints,
-            col_comm   ,
-            row_comm   ,
-            val_comm   ,
-            rc_comm    ,
-            rc         ,
-            row        ,
-            col        ,
-            val        ,
-            row_eval_k ,
-            col_eval_k ,
-            val_eval_k ,
-            row_eval_b ,
-            col_eval_b ,
-            val_eval_b ,
-            rc_eval_b   })
+            col_comm,
+            row_comm,
+            val_comm,
+            rc_comm,
+            rc,
+            row,
+            col,
+            val,
+            row_eval_k,
+            col_eval_k,
+            val_eval_k,
+            row_eval_b,
+            col_eval_b,
+            val_eval_b,
+            rc_eval_b,
+        })
     }
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut r = BufReader::new(File::open(path).unwrap());
 
     let srs = unsafe { &*srs };
 
-    let t : IoResult<_> = (|| {
+    let t: IoResult<_> = (|| {
         let domains = read_evaluation_domains(&mut r)?;
 
         let c0 = read_compiled(public_inputs, domains, a, &mut r)?;
@@ -339,7 +348,7 @@ pub extern "C" fn zexe_bn382_fq_index_read<'a>(
 
         let public_inputs = u64::read(&mut r)? as usize;
 
-        Ok( DlogIndex::<GAffine> {
+        Ok(DlogIndex::<GAffine> {
             compiled: [c0, c1, c2],
             domains,
             public_inputs,
@@ -356,16 +365,16 @@ pub extern "C" fn zexe_bn382_fq_index_read<'a>(
 // Fq verifier index stubs
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_create(
-    index: *const DlogIndex<GAffine>
+    index: *const DlogIndex<GAffine>,
 ) -> *const DlogVerifierIndex<GAffine> {
-    Box::into_raw(Box::new(unsafe {&(*index)}.verifier_index()))
+    Box::into_raw(Box::new(unsafe { &(*index) }.verifier_index()))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_urs<'a>(
-    index: *const DlogVerifierIndex<'a, GAffine>
+    index: *const DlogVerifierIndex<'a, GAffine>,
 ) -> *const SRS<GAffine> {
-    let index = unsafe { & *index };
+    let index = unsafe { &*index };
     let urs = index.srs.get_ref().clone();
     Box::into_raw(Box::new(urs))
 }
@@ -393,9 +402,10 @@ pub extern "C" fn zexe_bn382_fq_verifier_index_make<'a>(
     val_c: *const PolyComm<GAffine>,
     rc_c: *const PolyComm<GAffine>,
 ) -> *const DlogVerifierIndex<'a, GAffine> {
-    let srs : SRS<GAffine> = (unsafe { &*urs }).clone();
+    let srs: SRS<GAffine> = (unsafe { &*urs }).clone();
     let index = DlogVerifierIndex::<GAffine> {
-        domains: EvaluationDomains::create(variables, constraints, public_inputs, nonzero_entries).unwrap(),
+        domains: EvaluationDomains::create(variables, constraints, public_inputs, nonzero_entries)
+            .unwrap(),
         matrix_commitments: [
             marlin_protocol_dlog::index::MatrixValues {
                 row: (unsafe { &*row_a }).clone(),
@@ -426,22 +436,23 @@ pub extern "C" fn zexe_bn382_fq_verifier_index_make<'a>(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_verifier_index_delete(
-    x: *mut DlogVerifierIndex<GAffine>
-) {
+pub extern "C" fn zexe_bn382_fq_verifier_index_delete(x: *mut DlogVerifierIndex<GAffine>) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_write<'a>(
-    index : *const DlogVerifierIndex<GAffine>,
-    path: *const c_char) {
-    let index = unsafe { & *index };
+    index: *const DlogVerifierIndex<GAffine>,
+    path: *const c_char,
+) {
+    let index = unsafe { &*index };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut w = BufWriter::new(File::create(path).unwrap());
 
-    let t : IoResult<()> = (|| {
+    let t: IoResult<()> = (|| {
         for c in index.matrix_commitments.iter() {
             write_dlog_matrix_values(c, &mut w)?;
         }
@@ -455,14 +466,17 @@ pub extern "C" fn zexe_bn382_fq_verifier_index_write<'a>(
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_read<'a>(
-    srs : *const SRS<GAffine>,
-    path: *const c_char) -> *const DlogVerifierIndex<'a, GAffine> {
+    srs: *const SRS<GAffine>,
+    path: *const c_char,
+) -> *const DlogVerifierIndex<'a, GAffine> {
     let srs = unsafe { &*srs };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut r = BufReader::new(File::open(path).unwrap());
 
-    let t : IoResult<_> = (|| {
+    let t: IoResult<_> = (|| {
         let m0 = read_dlog_matrix_values(&mut r)?;
         let m1 = read_dlog_matrix_values(&mut r)?;
         let m2 = read_dlog_matrix_values(&mut r)?;
@@ -486,84 +500,108 @@ pub extern "C" fn zexe_bn382_fq_verifier_index_read<'a>(
 pub extern "C" fn zexe_bn382_fq_verifier_index_a_row_comm(
     index: *const DlogVerifierIndex<GAffine>,
 ) -> *const PolyComm<GAffine> {
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].row }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_a_col_comm(
     index: *const DlogVerifierIndex<GAffine>,
 ) -> *const PolyComm<GAffine> {
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].col }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_a_val_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].val }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_a_rc_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].rc }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].rc }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_b_row_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].row }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_b_col_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].col }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_b_val_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].val }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_b_rc_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].rc }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].rc }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_c_row_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].row }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_c_col_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].col }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_c_val_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].val }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_verifier_index_c_rc_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].rc }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].rc }).clone(),
+    ))
 }
 
 // Fq stubs
@@ -911,19 +949,14 @@ pub extern "C" fn zexe_bn382_g_add(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g_double(
-    x: *const GProjective,
-) -> *const GProjective {
+pub extern "C" fn zexe_bn382_g_double(x: *const GProjective) -> *const GProjective {
     let x_ = unsafe { &(*x) };
     let ret = x_.double();
     return Box::into_raw(Box::new(ret));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g_scale(
-    x: *const GProjective,
-    s: *const Fq,
-) -> *const GProjective {
+pub extern "C" fn zexe_bn382_g_scale(x: *const GProjective, s: *const Fq) -> *const GProjective {
     let x_ = unsafe { &(*x) };
     let s_ = unsafe { &(*s) };
     let ret = (*x_).mul(*s_);
@@ -973,10 +1006,7 @@ pub extern "C" fn zexe_bn382_g_of_affine_coordinates(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g_affine_create(
-    x: *const Fp,
-    y: *const Fp
-    ) -> *const GAffine {
+pub extern "C" fn zexe_bn382_g_affine_create(x: *const Fp, y: *const Fp) -> *const GAffine {
     let x = (unsafe { *x }).clone();
     let y = (unsafe { *y }).clone();
     Box::into_raw(Box::new(GAffine::new(x, y, false)))
@@ -1007,22 +1037,22 @@ pub extern "C" fn zexe_bn382_g_affine_delete(x: *mut GAffine) {
 
 // G affine pair
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g_affine_pair_0(
-    p: *const (GAffine, GAffine)) -> *const GAffine {
-    let (x0, _) = unsafe { *p};
+pub extern "C" fn zexe_bn382_g_affine_pair_0(p: *const (GAffine, GAffine)) -> *const GAffine {
+    let (x0, _) = unsafe { *p };
     return Box::into_raw(Box::new(x0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g_affine_pair_1(
-    p: *const (GAffine, GAffine)) -> *const GAffine {
-    let (_, x1) = unsafe { *p};
+pub extern "C" fn zexe_bn382_g_affine_pair_1(p: *const (GAffine, GAffine)) -> *const GAffine {
+    let (_, x1) = unsafe { *p };
     return Box::into_raw(Box::new(x1.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g_affine_pair_make(x0 : *const GAffine, x1 : *const GAffine)
--> *const (GAffine, GAffine) {
+pub extern "C" fn zexe_bn382_g_affine_pair_make(
+    x0: *const GAffine,
+    x1: *const GAffine,
+) -> *const (GAffine, GAffine) {
     let res = ((unsafe { *x0 }), (unsafe { *x1 }));
     return Box::into_raw(Box::new(res));
 }
@@ -1044,14 +1074,20 @@ pub extern "C" fn zexe_bn382_g_affine_pair_vector_length(v: *const Vec<(GAffine,
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g_affine_pair_vector_emplace_back(v: *mut Vec<(GAffine, GAffine)>, x: *const (GAffine, GAffine)) {
+pub extern "C" fn zexe_bn382_g_affine_pair_vector_emplace_back(
+    v: *mut Vec<(GAffine, GAffine)>,
+    x: *const (GAffine, GAffine),
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(*x_);
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g_affine_pair_vector_get(v: *mut Vec<(GAffine, GAffine)>, i: u32) -> *mut (GAffine, GAffine) {
+pub extern "C" fn zexe_bn382_g_affine_pair_vector_get(
+    v: *mut Vec<(GAffine, GAffine)>,
+    i: u32,
+) -> *mut (GAffine, GAffine) {
     let v_ = unsafe { &mut (*v) };
     return Box::into_raw(Box::new((*v_)[i as usize]));
 }
@@ -1109,107 +1145,98 @@ pub extern "C" fn zexe_bn382_fq_oracles_create(
     let index = unsafe { &(*index) };
     let proof = unsafe { &(*proof) };
 
-    let x_hat = 
-        evals_from_coeffs(proof.public.clone(), index.domains.x).interpolate();
-        // TODO: Should have no degree bound when we add the correct degree bound method
+    let x_hat = evals_from_coeffs(proof.public.clone(), index.domains.x).interpolate();
+    // TODO: Should have no degree bound when we add the correct degree bound method
     let x_hat_comm = index.srs.get_ref().commit(&x_hat, None);
 
-    let (mut sponge, o) = proof.oracles::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fq, SC>>(
-        index, x_hat_comm, &x_hat,
-    );
+    let (mut sponge, o) = proof
+        .oracles::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fq, SC>>(
+            index, x_hat_comm, &x_hat,
+        );
     let opening_prechallenges = proof.proof.prechallenges(&mut sponge);
 
-    return Box::into_raw(Box::new(FqOracles { o, opening_prechallenges }));
+    return Box::into_raw(Box::new(FqOracles {
+        o,
+        opening_prechallenges,
+    }));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_oracles_opening_prechallenges(
-    oracles: *const FqOracles
+    oracles: *const FqOracles,
 ) -> *const Vec<Fq> {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).opening_prechallenges.iter().map(|x| x.0).collect() ));
+    return Box::into_raw(Box::new(
+        (unsafe { &(*oracles) })
+            .opening_prechallenges
+            .iter()
+            .map(|x| x.0)
+            .collect(),
+    ));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_oracles_alpha(
-    oracles: *const FqOracles
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.alpha.clone() ));
+pub extern "C" fn zexe_bn382_fq_oracles_alpha(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.alpha.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_oracles_eta_a(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.eta_a.clone() ));
+pub extern "C" fn zexe_bn382_fq_oracles_eta_a(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.eta_a.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_oracles_eta_b(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.eta_b.clone() ));
+pub extern "C" fn zexe_bn382_fq_oracles_eta_b(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.eta_b.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_oracles_eta_c(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.eta_c.clone() ));
+pub extern "C" fn zexe_bn382_fq_oracles_eta_c(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.eta_c.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_oracles_beta1(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.beta[0].0.clone() ));
+pub extern "C" fn zexe_bn382_fq_oracles_beta1(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.beta[0].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_oracles_beta2(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.beta[1].0.clone() ));
+pub extern "C" fn zexe_bn382_fq_oracles_beta2(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.beta[1].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_oracles_beta3(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.beta[2].0.clone() ));
+pub extern "C" fn zexe_bn382_fq_oracles_beta3(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.beta[2].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_oracles_polys(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.polys.0.clone() ));
+pub extern "C" fn zexe_bn382_fq_oracles_polys(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.polys.0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_oracles_evals(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.evals.0.clone() ));
+pub extern "C" fn zexe_bn382_fq_oracles_evals(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.evals.0.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_oracles_x_hat_nocopy(
     oracles: *const FqOracles,
 ) -> *const [Vec<Fq>; 3] {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.x_hat.clone() ));
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.x_hat.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_oracles_digest_before_evaluations(
     oracles: *const FqOracles,
 ) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.digest_before_evaluations.clone() ));
+    return Box::into_raw(Box::new(
+        (unsafe { &(*oracles) }).o.digest_before_evaluations.clone(),
+    ));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_oracles_delete(
-    x: *mut FqOracles,
-    ) {
+pub extern "C" fn zexe_bn382_fq_oracles_delete(x: *mut FqOracles) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
@@ -1220,7 +1247,7 @@ pub extern "C" fn zexe_bn382_fq_proof_create(
     primary_input: *const Vec<Fq>,
     auxiliary_input: *const Vec<Fq>,
     prev_challenges: *const Vec<Fq>,
-    prev_sgs : *const Vec<GAffine>,
+    prev_sgs: *const Vec<GAffine>,
 ) -> *const DlogProof<GAffine> {
     let index = unsafe { &(*index) };
     let primary_input = unsafe { &(*primary_input) };
@@ -1228,28 +1255,40 @@ pub extern "C" fn zexe_bn382_fq_proof_create(
 
     let witness = prepare_witness(index.domains, primary_input, auxiliary_input);
 
-    let prev : Vec<(Vec<Fq>, PolyComm<GAffine>)> = {
-        let prev_challenges = unsafe { &*prev_challenges};
+    let prev: Vec<(Vec<Fq>, PolyComm<GAffine>)> = {
+        let prev_challenges = unsafe { &*prev_challenges };
         let prev_sgs = unsafe { &*prev_sgs };
-        if prev_challenges.len() == 0 {Vec::new()} else
-        {
+        if prev_challenges.len() == 0 {
+            Vec::new()
+        } else {
             let challenges_per_sg = prev_challenges.len() / prev_sgs.len();
-            prev_sgs.iter().enumerate().map( |(i, sg)| {
-                (
-                    prev_challenges[(i * challenges_per_sg)..(i+1)*challenges_per_sg].iter().map(|x| *x).collect(),
-                    PolyComm::<GAffine>{unshifted: vec![sg.clone()], shifted: None}
-                )
-            }).collect()
+            prev_sgs
+                .iter()
+                .enumerate()
+                .map(|(i, sg)| {
+                    (
+                        prev_challenges[(i * challenges_per_sg)..(i + 1) * challenges_per_sg]
+                            .iter()
+                            .map(|x| *x)
+                            .collect(),
+                        PolyComm::<GAffine> {
+                            unshifted: vec![sg.clone()],
+                            shifted: None,
+                        },
+                    )
+                })
+                .collect()
         }
     };
-    
+
     let rng = &mut rand_core::OsRng;
 
     let map = <Affine as CommitmentCurve>::Map::setup();
-    let proof = DlogProof::create::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fq, SC>>(
-        &map, &witness, &index, prev, rng,
-    )
-    .unwrap();
+    let proof =
+        DlogProof::create::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fq, SC>>(
+            &map, &witness, &index, prev, rng,
+        )
+        .unwrap();
 
     return Box::into_raw(Box::new(proof));
 }
@@ -1259,7 +1298,6 @@ pub extern "C" fn zexe_bn382_fq_proof_verify(
     index: *const DlogVerifierIndex<GAffine>,
     proof: *const DlogProof<GAffine>,
 ) -> bool {
-
     let index = unsafe { &(*index) };
     let proof = unsafe { (*proof).clone() };
     let group_map = <Affine as CommitmentCurve>::Map::setup();
@@ -1268,7 +1306,7 @@ pub extern "C" fn zexe_bn382_fq_proof_verify(
         &group_map,
         &[proof].to_vec(),
         &index,
-        &mut rand_core::OsRng
+        &mut rand_core::OsRng,
     )
 }
 
@@ -1292,55 +1330,64 @@ pub extern "C" fn zexe_bn382_fq_proof_batch_verify(
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_proof_make(
-    primary_input : *const Vec<Fq>,
+    primary_input: *const Vec<Fq>,
 
-    w_comm        : *const PolyComm<GAffine>,
-    za_comm       : *const PolyComm<GAffine>,
-    zb_comm       : *const PolyComm<GAffine>,
-    h1_comm       : *const PolyComm<GAffine>,
-    g1_comm       : *const PolyComm<GAffine>,
-    h2_comm       : *const PolyComm<GAffine>,
-    g2_comm       : *const PolyComm<GAffine>,
-    h3_comm       : *const PolyComm<GAffine>,
-    g3_comm       : *const PolyComm<GAffine>,
+    w_comm: *const PolyComm<GAffine>,
+    za_comm: *const PolyComm<GAffine>,
+    zb_comm: *const PolyComm<GAffine>,
+    h1_comm: *const PolyComm<GAffine>,
+    g1_comm: *const PolyComm<GAffine>,
+    h2_comm: *const PolyComm<GAffine>,
+    g2_comm: *const PolyComm<GAffine>,
+    h3_comm: *const PolyComm<GAffine>,
+    g3_comm: *const PolyComm<GAffine>,
 
-    sigma2        : *const Fq,
-    sigma3        : *const Fq, 
+    sigma2: *const Fq,
+    sigma3: *const Fq,
 
-    lr : *const Vec<(GAffine, GAffine)>,
-    z1 : *const Fq,
-    z2 : *const Fq,
-    delta : *const GAffine,
-    sg : *const GAffine,
+    lr: *const Vec<(GAffine, GAffine)>,
+    z1: *const Fq,
+    z2: *const Fq,
+    delta: *const GAffine,
+    sg: *const GAffine,
 
-    evals0 : *const DlogProofEvaluations<Fq>,
-    evals1 : *const DlogProofEvaluations<Fq>,
-    evals2 : *const DlogProofEvaluations<Fq>,
+    evals0: *const DlogProofEvaluations<Fq>,
+    evals1: *const DlogProofEvaluations<Fq>,
+    evals2: *const DlogProofEvaluations<Fq>,
 
     prev_challenges: *const Vec<Fq>,
-    prev_sgs : *const Vec<GAffine>,
-    ) -> *const DlogProof<GAffine> {
-
+    prev_sgs: *const Vec<GAffine>,
+) -> *const DlogProof<GAffine> {
     let public = unsafe { &(*primary_input) }.clone();
     // public.resize(ceil_pow2(public.len()), Fq::zero());
 
-    let prev : Vec<(Vec<Fq>, PolyComm<GAffine>)> = {
-        let prev_challenges = unsafe { &*prev_challenges};
+    let prev: Vec<(Vec<Fq>, PolyComm<GAffine>)> = {
+        let prev_challenges = unsafe { &*prev_challenges };
         let prev_sgs = unsafe { &*prev_sgs };
-        if prev_challenges.len() == 0 {Vec::new()} else
-        {
+        if prev_challenges.len() == 0 {
+            Vec::new()
+        } else {
             let challenges_per_sg = prev_challenges.len() / prev_sgs.len();
-            prev_sgs.iter().enumerate().map( |(i, sg)| {
-                (
-                    prev_challenges[(i * challenges_per_sg)..(i+1)*challenges_per_sg].iter().map(|x| *x).collect(),
-                    PolyComm::<GAffine>{unshifted: vec![sg.clone()], shifted: None}
-                )
-            }).collect()
+            prev_sgs
+                .iter()
+                .enumerate()
+                .map(|(i, sg)| {
+                    (
+                        prev_challenges[(i * challenges_per_sg)..(i + 1) * challenges_per_sg]
+                            .iter()
+                            .map(|x| *x)
+                            .collect(),
+                        PolyComm::<GAffine> {
+                            unshifted: vec![sg.clone()],
+                            shifted: None,
+                        },
+                    )
+                })
+                .collect()
         }
     };
 
     let res = DlogProof {
-
         prev_challenges: prev,
         proof: OpeningProof {
             lr: (unsafe { &*lr }).clone(),
@@ -1350,20 +1397,24 @@ pub extern "C" fn zexe_bn382_fq_proof_make(
             sg: (unsafe { *sg }).clone(),
         },
         w_comm: (unsafe { &*w_comm }).clone(),
-        za_comm: (unsafe { &*za_comm }).clone() ,
-        zb_comm: (unsafe { &*zb_comm }).clone() ,
-        h1_comm: (unsafe { &*h1_comm }).clone() ,
+        za_comm: (unsafe { &*za_comm }).clone(),
+        zb_comm: (unsafe { &*zb_comm }).clone(),
+        h1_comm: (unsafe { &*h1_comm }).clone(),
         g1_comm: (unsafe { &*g1_comm }).clone(),
-        h2_comm: (unsafe { &*h2_comm }).clone() ,
+        h2_comm: (unsafe { &*h2_comm }).clone(),
         g2_comm: (unsafe { &*g2_comm }).clone(),
-        h3_comm: (unsafe { &*h3_comm }).clone() ,
+        h3_comm: (unsafe { &*h3_comm }).clone(),
         g3_comm: (unsafe { &*g3_comm }).clone(),
 
         sigma2: (unsafe { *sigma2 }).clone(),
         sigma3: (unsafe { *sigma3 }).clone(),
 
         public,
-        evals: [(unsafe { &*evals0 }).clone(), (unsafe {& *evals1 }).clone(), (unsafe { &*evals2 }).clone(), ],
+        evals: [
+            (unsafe { &*evals0 }).clone(),
+            (unsafe { &*evals1 }).clone(),
+            (unsafe { &*evals2 }).clone(),
+        ],
     };
     return Box::into_raw(Box::new(res));
 }
@@ -1374,55 +1425,73 @@ pub extern "C" fn zexe_bn382_fq_proof_delete(x: *mut DlogProof<GAffine>) {
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_w_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe { &((*p).w_comm )}).clone();
+pub extern "C" fn zexe_bn382_fq_proof_w_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).w_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_za_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).za_comm )}).clone();
+pub extern "C" fn zexe_bn382_fq_proof_za_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).za_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_zb_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).zb_comm )}).clone();
+pub extern "C" fn zexe_bn382_fq_proof_zb_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).zb_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_h1_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).h1_comm )}).clone();
+pub extern "C" fn zexe_bn382_fq_proof_h1_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).h1_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_g1_comm_nocopy(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_bn382_fq_proof_g1_comm_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).g1_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_h2_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).h2_comm )}).clone();
+pub extern "C" fn zexe_bn382_fq_proof_h2_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).h2_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_g2_comm_nocopy(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_bn382_fq_proof_g2_comm_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).g2_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_h3_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_bn382_fq_proof_h3_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).h3_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_g3_comm_nocopy(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_bn382_fq_proof_g3_comm_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).g3_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1440,13 +1509,17 @@ pub extern "C" fn zexe_bn382_fq_proof_sigma3(p: *mut DlogProof<GAffine>) -> *con
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_proof(p: *mut DlogProof<GAffine>) -> *const OpeningProof<GAffine> {
+pub extern "C" fn zexe_bn382_fq_proof_proof(
+    p: *mut DlogProof<GAffine>,
+) -> *const OpeningProof<GAffine> {
     let x = (unsafe { &(*p).proof }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evals_nocopy(p: *mut DlogProof<GAffine>) -> *const [DlogProofEvaluations<Fq>; 3] {
+pub extern "C" fn zexe_bn382_fq_proof_evals_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const [DlogProofEvaluations<Fq>; 3] {
     let x = (unsafe { &(*p).evals }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1465,14 +1538,20 @@ pub extern "C" fn zexe_bn382_fq_proof_vector_length(v: *const Vec<DlogProof<GAff
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_vector_emplace_back(v: *mut Vec<DlogProof<GAffine>>, x: *const DlogProof<GAffine>) {
+pub extern "C" fn zexe_bn382_fq_proof_vector_emplace_back(
+    v: *mut Vec<DlogProof<GAffine>>,
+    x: *const DlogProof<GAffine>,
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(x_.clone());
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_vector_get(v: *mut Vec<DlogProof<GAffine>>, i: u32) -> *mut DlogProof<GAffine> {
+pub extern "C" fn zexe_bn382_fq_proof_vector_get(
+    v: *mut Vec<DlogProof<GAffine>>,
+    i: u32,
+) -> *mut DlogProof<GAffine> {
     let v_ = unsafe { &mut (*v) };
     return Box::into_raw(Box::new((*v_)[i as usize].clone()));
 }
@@ -1493,13 +1572,17 @@ pub extern "C" fn zexe_bn382_fq_opening_proof_delete(p: *mut OpeningProof<GAffin
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_opening_proof_sg(p: *const OpeningProof<GAffine>) -> *const GAffine {
+pub extern "C" fn zexe_bn382_fq_opening_proof_sg(
+    p: *const OpeningProof<GAffine>,
+) -> *const GAffine {
     let x = (unsafe { &(*p).sg }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_opening_proof_lr(p: *const OpeningProof<GAffine>) -> *const Vec<(GAffine, GAffine)> {
+pub extern "C" fn zexe_bn382_fq_opening_proof_lr(
+    p: *const OpeningProof<GAffine>,
+) -> *const Vec<(GAffine, GAffine)> {
     let x = (unsafe { &(*p).lr }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1517,7 +1600,9 @@ pub extern "C" fn zexe_bn382_fq_opening_proof_z2(p: *const OpeningProof<GAffine>
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_opening_proof_delta(p: *const OpeningProof<GAffine>) -> *const GAffine {
+pub extern "C" fn zexe_bn382_fq_opening_proof_delta(
+    p: *const OpeningProof<GAffine>,
+) -> *const GAffine {
     let x = (unsafe { &(*p).delta }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1525,103 +1610,137 @@ pub extern "C" fn zexe_bn382_fq_opening_proof_delta(p: *const OpeningProof<GAffi
 // Fq proof evaluations
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_w(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).w }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_w(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).w }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_za(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).za }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_za(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).za }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_zb(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).zb }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_zb(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).zb }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_h1(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).h1 }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_h1(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).h1 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_h2(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).h2 }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_h2(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).h2 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_h3(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).h3 }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_h3(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).h3 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_g1(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).g1 }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_g1(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).g1 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_g2(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).g2 }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_g2(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).g2 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_g3(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).g3 }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_g3(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).g3 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_row_nocopy(e: *const DlogProofEvaluations<Fq>) -> *const [Vec<Fq>; 3] {
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_row_nocopy(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const [Vec<Fq>; 3] {
     let x = (unsafe { &(*e).row }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_val_nocopy(e: *const DlogProofEvaluations<Fq>) -> *const [Vec<Fq>; 3] {
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_val_nocopy(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const [Vec<Fq>; 3] {
     let x = (unsafe { &(*e).val }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_col_nocopy(e: *const DlogProofEvaluations<Fq>) -> *const [Vec<Fq>; 3] {
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_col_nocopy(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const [Vec<Fq>; 3] {
     let x = (unsafe { &(*e).col }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_rc_nocopy(e: *const DlogProofEvaluations<Fq>) -> *const [Vec<Fq>; 3] {
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_rc_nocopy(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const [Vec<Fq>; 3] {
     let x = (unsafe { &(*e).rc }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_triple_0(e: *const [DlogProofEvaluations<Fq>; 3]) -> *const DlogProofEvaluations<Fq> {
-    let x = (unsafe { & (*e)[0] }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_triple_0(
+    e: *const [DlogProofEvaluations<Fq>; 3],
+) -> *const DlogProofEvaluations<Fq> {
+    let x = (unsafe { &(*e)[0] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_triple_1(e: *const [DlogProofEvaluations<Fq>; 3]) -> *const DlogProofEvaluations<Fq> {
-    let x = (unsafe { & (*e)[1] }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_triple_1(
+    e: *const [DlogProofEvaluations<Fq>; 3],
+) -> *const DlogProofEvaluations<Fq> {
+    let x = (unsafe { &(*e)[1] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_triple_2(e: *const [DlogProofEvaluations<Fq>; 3]) -> *const DlogProofEvaluations<Fq> {
-    let x = (unsafe { & (*e)[2] }).clone();
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_triple_2(
+    e: *const [DlogProofEvaluations<Fq>; 3],
+) -> *const DlogProofEvaluations<Fq> {
+    let x = (unsafe { &(*e)[2] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_proof_evaluations_triple_delete(x: *mut [DlogProofEvaluations<Fq>; 3]) {
+pub extern "C" fn zexe_bn382_fq_proof_evaluations_triple_delete(
+    x: *mut [DlogProofEvaluations<Fq>; 3],
+) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
@@ -1651,8 +1770,9 @@ pub extern "C" fn zexe_bn382_fq_proof_evaluations_make(
 
     rc_0: *const Vec<Fq>,
     rc_1: *const Vec<Fq>,
-    rc_2: *const Vec<Fq>) -> *const DlogProofEvaluations<Fq> {
-    let res : DlogProofEvaluations<Fq> = DlogProofEvaluations {
+    rc_2: *const Vec<Fq>,
+) -> *const DlogProofEvaluations<Fq> {
+    let res: DlogProofEvaluations<Fq> = DlogProofEvaluations {
         w: (unsafe { &*w }).clone(),
         za: (unsafe { &*za }).clone(),
         zb: (unsafe { &*zb }).clone(),
@@ -1662,22 +1782,26 @@ pub extern "C" fn zexe_bn382_fq_proof_evaluations_make(
         h1: (unsafe { &*h1 }).clone(),
         h2: (unsafe { &*h2 }).clone(),
         h3: (unsafe { &*h3 }).clone(),
-        row:
-            [ (unsafe {&*row_0}).clone(),
-                (unsafe {&*row_1}).clone(),
-                (unsafe {&*row_2}).clone() ],
-        col:
-            [ (unsafe {&*col_0}).clone(),
-                (unsafe {&*col_1}).clone(),
-                (unsafe {&*col_2}).clone() ],
-        val:
-            [ (unsafe {&*val_0}).clone(),
-                (unsafe {&*val_1}).clone(),
-                (unsafe {&*val_2}).clone() ],
-        rc:
-            [ (unsafe {&*rc_0}).clone(),
-                (unsafe {&*rc_1}).clone(),
-                (unsafe {&*rc_2}).clone() ],
+        row: [
+            (unsafe { &*row_0 }).clone(),
+            (unsafe { &*row_1 }).clone(),
+            (unsafe { &*row_2 }).clone(),
+        ],
+        col: [
+            (unsafe { &*col_0 }).clone(),
+            (unsafe { &*col_1 }).clone(),
+            (unsafe { &*col_2 }).clone(),
+        ],
+        val: [
+            (unsafe { &*val_0 }).clone(),
+            (unsafe { &*val_1 }).clone(),
+            (unsafe { &*val_2 }).clone(),
+        ],
+        rc: [
+            (unsafe { &*rc_0 }).clone(),
+            (unsafe { &*rc_1 }).clone(),
+            (unsafe { &*rc_2 }).clone(),
+        ],
     };
 
     return Box::into_raw(Box::new(res));
@@ -1690,33 +1814,39 @@ pub extern "C" fn zexe_bn382_fq_proof_evaluations_delete(x: *mut DlogProofEvalua
 
 // fq poly comm
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_poly_comm_unshifted(c: *const PolyComm<GAffine>) -> *const Vec<GAffine> {
-    let c = unsafe {& (*c) };
+pub extern "C" fn zexe_bn382_fq_poly_comm_unshifted(
+    c: *const PolyComm<GAffine>,
+) -> *const Vec<GAffine> {
+    let c = unsafe { &(*c) };
     return Box::into_raw(Box::new(c.unshifted.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fq_poly_comm_shifted(c: *const PolyComm<GAffine>) -> *const GAffine {
-    let c = unsafe {& (*c) };
+    let c = unsafe { &(*c) };
     match c.shifted {
         Some(g) => Box::into_raw(Box::new(g.clone())),
-        None =>  std::ptr::null()
+        None => std::ptr::null(),
     }
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_poly_comm_make
-(
+pub extern "C" fn zexe_bn382_fq_poly_comm_make(
     unshifted: *const Vec<GAffine>,
-    shifted: *const GAffine
-) -> *const PolyComm<GAffine>
-{
-    let unsh = unsafe {& (*unshifted) };
+    shifted: *const GAffine,
+) -> *const PolyComm<GAffine> {
+    let unsh = unsafe { &(*unshifted) };
 
-    let commitment = PolyComm
-    {
+    let commitment = PolyComm {
         unshifted: unsh.clone(),
-        shifted: if shifted == std::ptr::null() {None} else {Some ({let sh = unsafe {& (*shifted) }; *sh})}
+        shifted: if shifted == std::ptr::null() {
+            None
+        } else {
+            Some({
+                let sh = unsafe { &(*shifted) };
+                *sh
+            })
+        },
     };
 
     Box::into_raw(Box::new(commitment))

--- a/snarky-bn382/src/bn382_pairing.rs
+++ b/snarky-bn382/src/bn382_pairing.rs
@@ -1,41 +1,34 @@
 use crate::common::*;
 use algebra::{
-    ToBytes, FromBytes, One, Zero,
-    biginteger::{BigInteger384},
+    biginteger::BigInteger384,
     bn_382::{
-        Bn_382, G1Affine, G1Projective, G2Affine,
-        g1::Bn_382G1Parameters,
         fp::{Fp, FpParameters as Fp_params},
-        fq::{Fq},
+        fq::Fq,
+        g1::Bn_382G1Parameters,
+        Bn_382, G1Affine, G1Projective, G2Affine,
     },
-    curves::{
-        PairingEngine,
-        AffineCurve, ProjectiveCurve,
-    },
-    fields::{
-        Field, FpParameters, PrimeField, SquareRootField,
-    },
-    UniformRand,
+    curves::{AffineCurve, PairingEngine, ProjectiveCurve},
+    fields::{Field, FpParameters, PrimeField, SquareRootField},
+    FromBytes, One, ToBytes, UniformRand, Zero,
 };
-use marlin_protocol_pairing::index::{Index, MatrixValues, URSSpec, VerifierIndex};
 use commitment_pairing::urs::URS;
-use marlin_circuits::domains::EvaluationDomains;
 use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as Domain};
+use marlin_circuits::domains::EvaluationDomains;
+use marlin_protocol_pairing::index::{Index, MatrixValues, URSSpec, VerifierIndex};
 
-use oracle::{
-    self,
-    sponge::{DefaultFqSponge, DefaultFrSponge},
-    poseidon,
-    poseidon::{Sponge, MarlinSpongeConstants as SC},
-};
 use marlin_protocol_pairing::prover::{ProofEvaluations, ProverProof, RandomOracles};
+use oracle::{
+    self, poseidon,
+    poseidon::{MarlinSpongeConstants as SC, Sponge},
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+};
 use rand::rngs::StdRng;
 use rand_core;
 
-use std::os::raw::c_char;
 use std::ffi::CStr;
 use std::fs::File;
-use std::io::{Read, Result as IoResult, Write, BufReader, BufWriter};
+use std::io::{BufReader, BufWriter, Read, Result as IoResult, Write};
+use std::os::raw::c_char;
 
 // Fp stubs
 
@@ -312,29 +305,29 @@ pub extern "C" fn zexe_bn382_fp_vector_triple_delete(x: *mut [Fp; 3]) {
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_batch_pairing_check(
-// Pardon the tortured encoding. It's this way because we have to add
-// additional OCaml bindings for each specialized vector type.
-//
-// Each haloified proof i contains group elements
-// s_i
-// u_{i,j} for j in d
-// t_i
-// p_i
-//
-// and we must check
-// e(t_i, H) - e(p_i, beta H) = 0
-// e(s_i, H) - sum_j e(u_{i,j}, beta^{max-j} H) = 0 
-//
-// To check this we sample a, b at random and check
-//
-// e(sum_i b^i t_i, H) - e(sum_i b^i p_i, beta H) = 0
-// e(sum_i b^i s_i, H) - sum_j e(sum_i b^i u_{i,j}, beta^{max-j} H) = 0
-//
-// a [ e(sum_i b^i t_i, H) - e(sum_i b^i p_i, beta H) ] +
-// e(sum_i b^i s_i, H) - sum_j e(sum_i b^i u_{i,j}, beta^{max-j} H) = 0
-//
-// e(-a sum_i b^i p_i, beta H) +
-// e(sum_i b^i (s_i + a t_i), H) - sum_j e(sum_i b^i u_{i,j}, beta^{max-j} H) = 0
+    // Pardon the tortured encoding. It's this way because we have to add
+    // additional OCaml bindings for each specialized vector type.
+    //
+    // Each haloified proof i contains group elements
+    // s_i
+    // u_{i,j} for j in d
+    // t_i
+    // p_i
+    //
+    // and we must check
+    // e(t_i, H) - e(p_i, beta H) = 0
+    // e(s_i, H) - sum_j e(u_{i,j}, beta^{max-j} H) = 0
+    //
+    // To check this we sample a, b at random and check
+    //
+    // e(sum_i b^i t_i, H) - e(sum_i b^i p_i, beta H) = 0
+    // e(sum_i b^i s_i, H) - sum_j e(sum_i b^i u_{i,j}, beta^{max-j} H) = 0
+    //
+    // a [ e(sum_i b^i t_i, H) - e(sum_i b^i p_i, beta H) ] +
+    // e(sum_i b^i s_i, H) - sum_j e(sum_i b^i u_{i,j}, beta^{max-j} H) = 0
+    //
+    // e(-a sum_i b^i p_i, beta H) +
+    // e(sum_i b^i (s_i + a t_i), H) - sum_j e(sum_i b^i u_{i,j}, beta^{max-j} H) = 0
     urs: *const URS<Bn_382>,
     d: *const Vec<usize>,
     s: *const Vec<G1Affine>,
@@ -368,8 +361,9 @@ pub extern "C" fn zexe_bn382_batch_pairing_check(
     // Final value: -a sum_i b^i p_i
     let mut acc_beta_h = G1Projective::zero();
 
-    let u : Vec<Vec<G1Affine>> =
-        (0..n).map(|i| (0..k).map(|j| u[k*i + j]).collect()).collect();
+    let u: Vec<Vec<G1Affine>> = (0..n)
+        .map(|i| (0..k).map(|j| u[k * i + j]).collect())
+        .collect();
 
     // Optimization: Parallelize
     // Optimization:
@@ -394,14 +388,18 @@ pub extern "C" fn zexe_bn382_batch_pairing_check(
     }
 
     let mut table = vec![
-        (acc_h.into_affine().into(), G2Affine::prime_subgroup_generator().into()),
-        (acc_beta_h.into_affine().into(), urs.hx.into())
+        (
+            acc_h.into_affine().into(),
+            G2Affine::prime_subgroup_generator().into(),
+        ),
+        (acc_beta_h.into_affine().into(), urs.hx.into()),
     ];
     for (acc_j, j) in acc_d.iter().zip(d) {
         table.push((acc_j.into_affine().into(), urs.hn[&(urs.depth - j)].into()));
     }
 
-    Bn_382::final_exponentiation(&Bn_382::miller_loop(&table)).unwrap() == <Bn_382 as PairingEngine>::Fqk::one()
+    Bn_382::final_exponentiation(&Bn_382::miller_loop(&table)).unwrap()
+        == <Bn_382 as PairingEngine>::Fqk::one()
 }
 
 // Fp proof
@@ -417,9 +415,10 @@ pub extern "C" fn zexe_bn382_fp_proof_create(
 
     let witness = prepare_witness(index.domains, primary_input, auxiliary_input);
 
-    let proof = ProverProof::create::<DefaultFqSponge<Bn_382G1Parameters, SC>, DefaultFrSponge<Fp, SC>>(
-        &witness, &index,
-    )
+    let proof = ProverProof::create::<
+        DefaultFqSponge<Bn_382G1Parameters, SC>,
+        DefaultFrSponge<Fp, SC>,
+    >(&witness, &index)
     .unwrap();
 
     return Box::into_raw(Box::new(proof));
@@ -434,13 +433,13 @@ pub extern "C" fn zexe_bn382_fp_proof_batch_verify(
     let index = unsafe { &(*index) };
     let proofs = unsafe { &(*proofs) };
 
-    match ProverProof::<Bn_382>::verify::<DefaultFqSponge<Bn_382G1Parameters, SC>, DefaultFrSponge<Fp, SC>>(
-        proofs,
-        index,
-        &mut rand_core::OsRng,
-    ) {
+    match ProverProof::<Bn_382>::verify::<
+        DefaultFqSponge<Bn_382G1Parameters, SC>,
+        DefaultFrSponge<Fp, SC>,
+    >(proofs, index, &mut rand_core::OsRng)
+    {
         Ok(_) => true,
-        Err(_) => false
+        Err(_) => false,
     }
 }
 
@@ -449,43 +448,41 @@ pub extern "C" fn zexe_bn382_fp_proof_verify(
     index: *const VerifierIndex<Bn_382>,
     proof: *const ProverProof<Bn_382>,
 ) -> bool {
-
     let index = unsafe { &(*index) };
     let proof = unsafe { (*proof).clone() };
 
     match ProverProof::verify::<DefaultFqSponge<Bn_382G1Parameters, SC>, DefaultFrSponge<Fp, SC>>(
         &[proof].to_vec(),
         &index,
-        &mut rand_core::OsRng
-    )
-    {
+        &mut rand_core::OsRng,
+    ) {
         Ok(status) => status,
-        _ => false
+        _ => false,
     }
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_proof_make(
-    primary_input : *const Vec<Fp>,
+    primary_input: *const Vec<Fp>,
 
-    w_comm        : *const G1Affine,
-    za_comm       : *const G1Affine,
-    zb_comm       : *const G1Affine,
-    h1_comm       : *const G1Affine,
-    g1_comm_0     : *const G1Affine,
-    g1_comm_1     : *const G1Affine,
-    h2_comm       : *const G1Affine,
-    g2_comm_0     : *const G1Affine,
-    g2_comm_1     : *const G1Affine,
-    h3_comm       : *const G1Affine,
-    g3_comm_0     : *const G1Affine,
-    g3_comm_1     : *const G1Affine,
-    proof1        : *const G1Affine,
-    proof2        : *const G1Affine,
-    proof3        : *const G1Affine,
+    w_comm: *const G1Affine,
+    za_comm: *const G1Affine,
+    zb_comm: *const G1Affine,
+    h1_comm: *const G1Affine,
+    g1_comm_0: *const G1Affine,
+    g1_comm_1: *const G1Affine,
+    h2_comm: *const G1Affine,
+    g2_comm_0: *const G1Affine,
+    g2_comm_1: *const G1Affine,
+    h3_comm: *const G1Affine,
+    g3_comm_0: *const G1Affine,
+    g3_comm_1: *const G1Affine,
+    proof1: *const G1Affine,
+    proof2: *const G1Affine,
+    proof3: *const G1Affine,
 
-    sigma2        : *const Fp,
-    sigma3        : *const Fp,
+    sigma2: *const Fp,
+    sigma3: *const Fp,
 
     w: *const Fp,
     za: *const Fp,
@@ -518,47 +515,60 @@ pub extern "C" fn zexe_bn382_fp_proof_make(
 
     let proof = ProverProof {
         w_comm: (unsafe { *w_comm }).clone(),
-        za_comm: (unsafe { *za_comm }).clone() ,
-        zb_comm: (unsafe { *zb_comm }).clone() ,
-        h1_comm: (unsafe { *h1_comm }).clone() ,
-        g1_comm: ((unsafe { *g1_comm_0 }).clone(),(unsafe { *g1_comm_1 }).clone()),
-        h2_comm: (unsafe { *h2_comm }).clone() ,
-        g2_comm: ((unsafe { *g2_comm_0 }).clone(),(unsafe { *g2_comm_1 }).clone()),
-        h3_comm: (unsafe { *h3_comm }).clone() ,
-        g3_comm: ((unsafe { *g3_comm_0 }).clone(),(unsafe { *g3_comm_1 }).clone()),
-        proof1: (unsafe { *proof1 }).clone() ,
-        proof2: (unsafe { *proof2 }).clone() ,
-        proof3: (unsafe { *proof3 }).clone() ,
+        za_comm: (unsafe { *za_comm }).clone(),
+        zb_comm: (unsafe { *zb_comm }).clone(),
+        h1_comm: (unsafe { *h1_comm }).clone(),
+        g1_comm: (
+            (unsafe { *g1_comm_0 }).clone(),
+            (unsafe { *g1_comm_1 }).clone(),
+        ),
+        h2_comm: (unsafe { *h2_comm }).clone(),
+        g2_comm: (
+            (unsafe { *g2_comm_0 }).clone(),
+            (unsafe { *g2_comm_1 }).clone(),
+        ),
+        h3_comm: (unsafe { *h3_comm }).clone(),
+        g3_comm: (
+            (unsafe { *g3_comm_0 }).clone(),
+            (unsafe { *g3_comm_1 }).clone(),
+        ),
+        proof1: (unsafe { *proof1 }).clone(),
+        proof2: (unsafe { *proof2 }).clone(),
+        proof3: (unsafe { *proof3 }).clone(),
         public,
         sigma2: (unsafe { *sigma2 }).clone(),
         sigma3: (unsafe { *sigma3 }).clone(),
         evals: ProofEvaluations {
-            w :(unsafe {*w}).clone(),
-            za:(unsafe {*za}).clone(),
-            zb:(unsafe {*zb}).clone(),
-            h1:(unsafe {*h1}).clone(),
-            g1:(unsafe {*g1}).clone(),
-            h2:(unsafe {*h2}).clone(),
-            g2:(unsafe {*g2}).clone(),
-            h3:(unsafe {*h3}).clone(),
-            g3:(unsafe {*g3}).clone(),
-            row:
-                [ (unsafe {*row_0}).clone(),
-                  (unsafe {*row_1}).clone(),
-                  (unsafe {*row_2}).clone() ],
-            col:
-                [ (unsafe {*col_0}).clone(),
-                  (unsafe {*col_1}).clone(),
-                  (unsafe {*col_2}).clone() ],
-            val:
-                [ (unsafe {*val_0}).clone(),
-                  (unsafe {*val_1}).clone(),
-                  (unsafe {*val_2}).clone() ],
-            rc:
-                [ (unsafe {*rc_0}).clone(),
-                  (unsafe {*rc_1}).clone(),
-                  (unsafe {*rc_2}).clone() ],
-        }
+            w: (unsafe { *w }).clone(),
+            za: (unsafe { *za }).clone(),
+            zb: (unsafe { *zb }).clone(),
+            h1: (unsafe { *h1 }).clone(),
+            g1: (unsafe { *g1 }).clone(),
+            h2: (unsafe { *h2 }).clone(),
+            g2: (unsafe { *g2 }).clone(),
+            h3: (unsafe { *h3 }).clone(),
+            g3: (unsafe { *g3 }).clone(),
+            row: [
+                (unsafe { *row_0 }).clone(),
+                (unsafe { *row_1 }).clone(),
+                (unsafe { *row_2 }).clone(),
+            ],
+            col: [
+                (unsafe { *col_0 }).clone(),
+                (unsafe { *col_1 }).clone(),
+                (unsafe { *col_2 }).clone(),
+            ],
+            val: [
+                (unsafe { *val_0 }).clone(),
+                (unsafe { *val_1 }).clone(),
+                (unsafe { *val_2 }).clone(),
+            ],
+            rc: [
+                (unsafe { *rc_0 }).clone(),
+                (unsafe { *rc_1 }).clone(),
+                (unsafe { *rc_2 }).clone(),
+            ],
+        },
     };
 
     return Box::into_raw(Box::new(proof));
@@ -594,8 +604,10 @@ pub extern "C" fn zexe_bn382_fp_proof_h1_comm(p: *mut ProverProof<Bn_382>) -> *c
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_proof_g1_comm_nocopy(p: *mut ProverProof<Bn_382>) -> *const (G1Affine, G1Affine) {
-    let x = unsafe {(*p).g1_comm};
+pub extern "C" fn zexe_bn382_fp_proof_g1_comm_nocopy(
+    p: *mut ProverProof<Bn_382>,
+) -> *const (G1Affine, G1Affine) {
+    let x = unsafe { (*p).g1_comm };
     return Box::into_raw(Box::new(x));
 }
 
@@ -606,7 +618,9 @@ pub extern "C" fn zexe_bn382_fp_proof_h2_comm(p: *mut ProverProof<Bn_382>) -> *c
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_proof_g2_comm_nocopy(p: *mut ProverProof<Bn_382>) -> *const (G1Affine, G1Affine) {
+pub extern "C" fn zexe_bn382_fp_proof_g2_comm_nocopy(
+    p: *mut ProverProof<Bn_382>,
+) -> *const (G1Affine, G1Affine) {
     let x = unsafe { (*p).g2_comm };
     return Box::into_raw(Box::new(x));
 }
@@ -618,21 +632,25 @@ pub extern "C" fn zexe_bn382_fp_proof_h3_comm(p: *mut ProverProof<Bn_382>) -> *c
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_proof_g3_comm_nocopy(p: *mut ProverProof<Bn_382>) -> *const (G1Affine, G1Affine) {
+pub extern "C" fn zexe_bn382_fp_proof_g3_comm_nocopy(
+    p: *mut ProverProof<Bn_382>,
+) -> *const (G1Affine, G1Affine) {
     let x = unsafe { (*p).g3_comm };
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_proof_commitment_with_degree_bound_0(
-    p: *const (G1Affine, G1Affine)) -> *const G1Affine {
-    let (x0, _) = unsafe { *p};
+    p: *const (G1Affine, G1Affine),
+) -> *const G1Affine {
+    let (x0, _) = unsafe { *p };
     return Box::into_raw(Box::new(x0.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_proof_commitment_with_degree_bound_1(
-    p: *const (G1Affine, G1Affine)) -> *const G1Affine {
+    p: *const (G1Affine, G1Affine),
+) -> *const G1Affine {
     let (_, x1) = unsafe { *p };
     return Box::into_raw(Box::new(x1.clone()));
 }
@@ -795,14 +813,20 @@ pub extern "C" fn zexe_bn382_fp_proof_vector_length(v: *const Vec<ProverProof<Bn
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_proof_vector_emplace_back(v: *mut Vec<ProverProof<Bn_382>>, x: *const ProverProof<Bn_382>) {
+pub extern "C" fn zexe_bn382_fp_proof_vector_emplace_back(
+    v: *mut Vec<ProverProof<Bn_382>>,
+    x: *const ProverProof<Bn_382>,
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(x_.clone());
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_proof_vector_get(v: *mut Vec<ProverProof<Bn_382>>, i: u32) -> *mut ProverProof<Bn_382> {
+pub extern "C" fn zexe_bn382_fp_proof_vector_get(
+    v: *mut Vec<ProverProof<Bn_382>>,
+    i: u32,
+) -> *mut ProverProof<Bn_382> {
     let v_ = unsafe { &mut (*v) };
     return Box::into_raw(Box::new(v_[i as usize].clone()));
 }
@@ -835,108 +859,89 @@ pub extern "C" fn zexe_bn382_fp_oracles_create(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_alpha(
-    oracles: *const RandomOracles<Fp>,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).alpha.clone() ));
+pub extern "C" fn zexe_bn382_fp_oracles_alpha(oracles: *const RandomOracles<Fp>) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).alpha.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_eta_a(
-    oracles: *const RandomOracles<Fp>,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).eta_a.clone() ));
+pub extern "C" fn zexe_bn382_fp_oracles_eta_a(oracles: *const RandomOracles<Fp>) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).eta_a.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_eta_b(
-    oracles: *const RandomOracles<Fp>,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).eta_b.clone() ));
+pub extern "C" fn zexe_bn382_fp_oracles_eta_b(oracles: *const RandomOracles<Fp>) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).eta_b.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_eta_c(
-    oracles: *const RandomOracles<Fp>,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).eta_c.clone() ));
+pub extern "C" fn zexe_bn382_fp_oracles_eta_c(oracles: *const RandomOracles<Fp>) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).eta_c.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_beta1(
-    oracles: *const RandomOracles<Fp>,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).beta[0].0.clone() ));
+pub extern "C" fn zexe_bn382_fp_oracles_beta1(oracles: *const RandomOracles<Fp>) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).beta[0].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_beta2(
-    oracles: *const RandomOracles<Fp>,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).beta[1].0.clone() ));
+pub extern "C" fn zexe_bn382_fp_oracles_beta2(oracles: *const RandomOracles<Fp>) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).beta[1].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_beta3(
-    oracles: *const RandomOracles<Fp>,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).beta[2].0.clone() ));
+pub extern "C" fn zexe_bn382_fp_oracles_beta3(oracles: *const RandomOracles<Fp>) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).beta[2].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_r_k(
-    oracles: *const RandomOracles<Fp>,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).r_k.0.clone() ));
+pub extern "C" fn zexe_bn382_fp_oracles_r_k(oracles: *const RandomOracles<Fp>) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).r_k.0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_batch(
-    oracles: *const RandomOracles<Fp>,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).batch.0.clone() ));
+pub extern "C" fn zexe_bn382_fp_oracles_batch(oracles: *const RandomOracles<Fp>) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).batch.0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_r(
-    oracles: *const RandomOracles<Fp>,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).r.0.clone() ));
+pub extern "C" fn zexe_bn382_fp_oracles_r(oracles: *const RandomOracles<Fp>) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).r.0.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_oracles_x_hat_beta1(
     oracles: *const RandomOracles<Fp>,
 ) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).x_hat_beta1.clone() ));
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).x_hat_beta1.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_oracles_digest_before_evaluations(
     oracles: *const RandomOracles<Fp>,
 ) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).digest_before_evaluations.clone() ));
+    return Box::into_raw(Box::new(
+        (unsafe { &(*oracles) }).digest_before_evaluations.clone(),
+    ));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_oracles_delete(
-    x: *mut RandomOracles<Fp>) {
+pub extern "C" fn zexe_bn382_fp_oracles_delete(x: *mut RandomOracles<Fp>) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
 // Fp verifier index stubs
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_create(
-    index: *const Index<Bn_382>
+    index: *const Index<Bn_382>,
 ) -> *const VerifierIndex<Bn_382> {
-    Box::into_raw(Box::new(unsafe {&(*index)}.verifier_index()))
+    Box::into_raw(Box::new(unsafe { &(*index) }.verifier_index()))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_urs(
-    index: *const VerifierIndex<Bn_382>
+    index: *const VerifierIndex<Bn_382>,
 ) -> *const URS<Bn_382> {
-    let index = unsafe { & *index };
+    let index = unsafe { &*index };
     let urs = index.urs.clone();
     Box::into_raw(Box::new(urs))
 }
@@ -967,39 +972,57 @@ pub extern "C" fn zexe_bn382_fp_verifier_index_make(
     let urs: URS<Bn_382> = (unsafe { &*urs }).clone();
     let (endo_q, endo_r) = marlin_protocol_pairing::index::endos::<Bn_382>();
     let index = VerifierIndex {
-        domains: EvaluationDomains::create(variables, constraints, public_inputs, nonzero_entries).unwrap(),
+        domains: EvaluationDomains::create(variables, constraints, public_inputs, nonzero_entries)
+            .unwrap(),
         matrix_commitments: [
-            MatrixValues { row: (unsafe {*row_a}).clone(), col: (unsafe {*col_a}).clone(), val: (unsafe {*val_a}).clone(), rc: (unsafe {*rc_a}).clone() },
-            MatrixValues { row: (unsafe {*row_b}).clone(), col: (unsafe {*col_b}).clone(), val: (unsafe {*val_b}).clone(), rc: (unsafe {*rc_b}).clone() },
-            MatrixValues { row: (unsafe {*row_c}).clone(), col: (unsafe {*col_c}).clone(), val: (unsafe {*val_c}).clone(), rc: (unsafe {*rc_c}).clone() },
+            MatrixValues {
+                row: (unsafe { *row_a }).clone(),
+                col: (unsafe { *col_a }).clone(),
+                val: (unsafe { *val_a }).clone(),
+                rc: (unsafe { *rc_a }).clone(),
+            },
+            MatrixValues {
+                row: (unsafe { *row_b }).clone(),
+                col: (unsafe { *col_b }).clone(),
+                val: (unsafe { *val_b }).clone(),
+                rc: (unsafe { *rc_b }).clone(),
+            },
+            MatrixValues {
+                row: (unsafe { *row_c }).clone(),
+                col: (unsafe { *col_c }).clone(),
+                val: (unsafe { *val_c }).clone(),
+                rc: (unsafe { *rc_c }).clone(),
+            },
         ],
         fq_sponge_params: oracle::bn_382::fq::params(),
         fr_sponge_params: oracle::bn_382::fp::params(),
         max_degree,
         public_inputs,
         urs,
-        endo_q, endo_r
+        endo_q,
+        endo_r,
     };
     Box::into_raw(Box::new(index))
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_verifier_index_delete(
-    x: *mut VerifierIndex<Bn_382>
-) {
+pub extern "C" fn zexe_bn382_fp_verifier_index_delete(x: *mut VerifierIndex<Bn_382>) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_write<'a>(
-    index : *const VerifierIndex<Bn_382>,
-    path: *const c_char) {
-    let index = unsafe { & *index };
+    index: *const VerifierIndex<Bn_382>,
+    path: *const c_char,
+) {
+    let index = unsafe { &*index };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut w = BufWriter::new(File::create(path).unwrap());
 
-    let t : IoResult<()> = (|| {
+    let t: IoResult<()> = (|| {
         for c in index.matrix_commitments.iter() {
             write_matrix_values(c, &mut w)?;
         }
@@ -1014,11 +1037,14 @@ pub extern "C" fn zexe_bn382_fp_verifier_index_write<'a>(
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_read<'a>(
-    path: *const c_char) -> *const VerifierIndex<Bn_382> {
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    path: *const c_char,
+) -> *const VerifierIndex<Bn_382> {
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut r = BufReader::new(File::open(path).unwrap());
 
-    let t : IoResult<_> = (|| {
+    let t: IoResult<_> = (|| {
         let m0 = read_matrix_values(&mut r)?;
         let m1 = read_matrix_values(&mut r)?;
         let m2 = read_matrix_values(&mut r)?;
@@ -1033,7 +1059,8 @@ pub extern "C" fn zexe_bn382_fp_verifier_index_read<'a>(
             public_inputs,
             max_degree,
             urs,
-            endo_q, endo_r,
+            endo_q,
+            endo_r,
             fr_sponge_params: oracle::bn_382::fp::params(),
             fq_sponge_params: oracle::bn_382::fq::params(),
         })
@@ -1045,90 +1072,118 @@ pub extern "C" fn zexe_bn382_fp_verifier_index_read<'a>(
 pub extern "C" fn zexe_bn382_fp_verifier_index_a_row_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[0].row }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[0].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_a_col_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[0].col }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[0].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_a_val_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[0].val }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[0].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_a_rc_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[0].rc }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[0].rc }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_b_row_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[1].row }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[1].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_b_col_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[1].col }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[1].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_b_val_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[1].val }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[1].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_b_rc_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[1].rc }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[1].rc }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_c_row_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[2].row }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[2].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_c_col_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[2].col }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[2].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_c_val_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[2].val }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[2].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_verifier_index_c_rc_comm(
     index: *const VerifierIndex<Bn_382>,
 ) -> *const G1Affine {
-    Box::into_raw(Box::new((unsafe { (*index).matrix_commitments[2].rc }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { (*index).matrix_commitments[2].rc }).clone(),
+    ))
 }
 
 // Fp URS stubs
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_urs_create(depth : usize) -> *const URS<Bn_382> {
-    Box::into_raw(Box::new(URS::create(depth, (0..depth).collect(), &mut rand_core::OsRng)))
+pub extern "C" fn zexe_bn382_fp_urs_create(depth: usize) -> *const URS<Bn_382> {
+    Box::into_raw(Box::new(URS::create(
+        depth,
+        (0..depth).collect(),
+        &mut rand_core::OsRng,
+    )))
 }
 
 #[no_mangle]
@@ -1148,7 +1203,9 @@ pub extern "C" fn zexe_bn382_fp_urs_write(urs: *mut URS<Bn_382>, path: *mut c_ch
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_urs_read(path: *mut c_char) -> *const URS<Bn_382> {
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let file = BufReader::new(File::open(path).unwrap());
     let res = URS::<Bn_382>::read(file).unwrap();
     return Box::into_raw(Box::new(res));
@@ -1156,14 +1213,16 @@ pub extern "C" fn zexe_bn382_fp_urs_read(path: *mut c_char) -> *const URS<Bn_382
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_urs_lagrange_commitment(
-    urs : *const URS<Bn_382>,
-    domain_size : usize,
-    i: usize)
--> *const G1Affine {
+    urs: *const URS<Bn_382>,
+    domain_size: usize,
+    i: usize,
+) -> *const G1Affine {
     let urs = unsafe { &*urs };
     let x_domain = EvaluationDomain::<Fp>::new(domain_size).unwrap();
 
-    let evals = (0..domain_size).map(|j| if i == j { Fp::one() } else { Fp::zero() }).collect();
+    let evals = (0..domain_size)
+        .map(|j| if i == j { Fp::one() } else { Fp::zero() })
+        .collect();
     let p = Evaluations::<Fp>::from_vec_and_domain(evals, x_domain).interpolate();
     let res = urs.commit(&p).unwrap();
 
@@ -1172,10 +1231,10 @@ pub extern "C" fn zexe_bn382_fp_urs_lagrange_commitment(
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_urs_commit_evaluations(
-    urs : *const URS<Bn_382>,
-    domain_size : usize,
-    evals : *const Vec<Fp>)
--> *const G1Affine {
+    urs: *const URS<Bn_382>,
+    domain_size: usize,
+    evals: *const Vec<Fp>,
+) -> *const G1Affine {
     let urs = unsafe { &*urs };
     let x_domain = EvaluationDomain::<Fp>::new(domain_size).unwrap();
 
@@ -1188,33 +1247,39 @@ pub extern "C" fn zexe_bn382_fp_urs_commit_evaluations(
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_urs_dummy_degree_bound_checks(
-    urs : *const URS<Bn_382>,
-    bounds : *const Vec<usize>,
-    )
--> *const Vec<G1Affine> {
+    urs: *const URS<Bn_382>,
+    bounds: *const Vec<usize>,
+) -> *const Vec<G1Affine> {
     let urs = unsafe { &*urs };
     let bounds = unsafe { &*bounds };
-    let comms : Vec<_> = bounds.iter().map(|b| {
-        let p = DensePolynomial::<Fp>::from_coefficients_vec((0..*b).map(|i| {
-            if i == 0 {
-                Fp::one()
-            } else {
-                Fp::zero()
-            }
-        }).collect());
-        urs.commit_with_degree_bound(&p, *b).unwrap()
-    }).collect();
+    let comms: Vec<_> = bounds
+        .iter()
+        .map(|b| {
+            let p = DensePolynomial::<Fp>::from_coefficients_vec(
+                (0..*b)
+                    .map(|i| if i == 0 { Fp::one() } else { Fp::zero() })
+                    .collect(),
+            );
+            urs.commit_with_degree_bound(&p, *b).unwrap()
+        })
+        .collect();
 
     let cs = comms.iter().map(|(_, c)| *c);
     let ss = comms.iter().map(|(s, _)| *s);
 
-    let rs : Vec<Fp> = bounds.iter().enumerate().map(|(_, i)| ((i + 2) as u64).into()).collect();
+    let rs: Vec<Fp> = bounds
+        .iter()
+        .enumerate()
+        .map(|(_, i)| ((i + 2) as u64).into())
+        .collect();
 
-    let shifted : G1Affine =
-        ss.zip(rs.iter()).map(|(s, r)| s.mul(*r))
-        .fold(G1Projective::zero(), |acc, x| acc + &x).into_affine();
+    let shifted: G1Affine = ss
+        .zip(rs.iter())
+        .map(|(s, r)| s.mul(*r))
+        .fold(G1Projective::zero(), |acc, x| acc + &x)
+        .into_affine();
 
-    let mut res = vec![ shifted ];
+    let mut res = vec![shifted];
     res.extend(cs.zip(rs.iter()).map(|(c, r)| c.mul(*r).into_affine()));
 
     Box::into_raw(Box::new(res))
@@ -1222,8 +1287,8 @@ pub extern "C" fn zexe_bn382_fp_urs_dummy_degree_bound_checks(
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_urs_dummy_opening_check(
-    urs : *const URS<Bn_382>)
--> *const (G1Affine, G1Affine) {
+    urs: *const URS<Bn_382>,
+) -> *const (G1Affine, G1Affine) {
     /*
        (f - [v] + z pi, pi)
 
@@ -1239,23 +1304,24 @@ pub extern "C" fn zexe_bn382_fp_urs_dummy_opening_check(
     let v = p.evaluate(z);
     let pi = urs.open(vec![&p], Fp::one(), z).unwrap();
 
-    let res =
-        ( (f.into_projective() - &(G1Affine::prime_subgroup_generator().mul(v)) + & pi.mul(z))
-          .into_affine()
-        , pi);
+    let res = (
+        (f.into_projective() - &(G1Affine::prime_subgroup_generator().mul(v)) + &pi.mul(z))
+            .into_affine(),
+        pi,
+    );
 
     Box::into_raw(Box::new(res))
 }
 
 // Fp index stubs
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_index_domain_h_size<'a>(i : *const Index<'a, Bn_382>) -> usize {
-    (unsafe { & *i }).domains.h.size()
+pub extern "C" fn zexe_bn382_fp_index_domain_h_size<'a>(i: *const Index<'a, Bn_382>) -> usize {
+    (unsafe { &*i }).domains.h.size()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_index_domain_k_size<'a>(i : *const Index<'a, Bn_382>) -> usize {
-    (unsafe { & *i }).domains.k.size()
+pub extern "C" fn zexe_bn382_fp_index_domain_k_size<'a>(i: *const Index<'a, Bn_382>) -> usize {
+    (unsafe { &*i }).domains.k.size()
 }
 
 #[no_mangle]
@@ -1265,7 +1331,7 @@ pub extern "C" fn zexe_bn382_fp_index_create<'a>(
     c: *mut Vec<(Vec<usize>, Vec<Fp>)>,
     vars: usize,
     public_inputs: usize,
-    urs : *mut URS<Bn_382>
+    urs: *mut URS<Bn_382>,
 ) -> *mut Index<'a, Bn_382> {
     assert!(public_inputs > 0);
 
@@ -1276,7 +1342,11 @@ pub extern "C" fn zexe_bn382_fp_index_create<'a>(
 
     let num_constraints = a.len();
 
-    let m = if num_constraints > vars { num_constraints } else { vars };
+    let m = if num_constraints > vars {
+        num_constraints
+    } else {
+        vars
+    };
 
     let h_group_size = Domain::<Fp>::compute_size_of_domain(m).unwrap();
     let h_to_x_ratio = {
@@ -1304,33 +1374,30 @@ pub extern "C" fn zexe_bn382_fp_index_delete(x: *mut Index<Bn_382>) {
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_index_nonzero_entries(
-    index: *const Index<Bn_382>,
-) -> usize {
+pub extern "C" fn zexe_bn382_fp_index_nonzero_entries(index: *const Index<Bn_382>) -> usize {
     let index = unsafe { &*index };
-    index.compiled.iter().map(|x| x.constraints.nnz()).max().unwrap()
+    index
+        .compiled
+        .iter()
+        .map(|x| x.constraints.nnz())
+        .max()
+        .unwrap()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_index_max_degree(
-    index: *const Index<Bn_382>,
-) -> usize {
+pub extern "C" fn zexe_bn382_fp_index_max_degree(index: *const Index<Bn_382>) -> usize {
     let index = unsafe { &*index };
     index.urs.get_ref().max_degree()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_index_num_variables(
-    index: *const Index<Bn_382>,
-) -> usize {
+pub extern "C" fn zexe_bn382_fp_index_num_variables(index: *const Index<Bn_382>) -> usize {
     let index = unsafe { &*index };
     index.compiled[0].constraints.shape().0
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fp_index_public_inputs(
-    index: *const Index<Bn_382>,
-) -> usize {
+pub extern "C" fn zexe_bn382_fp_index_public_inputs(index: *const Index<Bn_382>) -> usize {
     let index = unsafe { &*index };
     index.public_inputs
 }
@@ -1352,22 +1419,24 @@ pub extern "C" fn zexe_bn382_fp_index_write<'a>(
         write_dense_polynomial(&c.row, &mut w)?;
         write_dense_polynomial(&c.col, &mut w)?;
         write_dense_polynomial(&c.val, &mut w)?;
-        write_evaluations(& c.row_eval_k, &mut w)?;
-        write_evaluations(& c.col_eval_k, &mut w)?;
-        write_evaluations(& c.val_eval_k, &mut w)?;
-        write_evaluations(& c.row_eval_b, &mut w)?;
-        write_evaluations(& c.col_eval_b, &mut w)?;
-        write_evaluations(& c.val_eval_b, &mut w)?;
-        write_evaluations(& c.rc_eval_b , &mut w)?;
+        write_evaluations(&c.row_eval_k, &mut w)?;
+        write_evaluations(&c.col_eval_k, &mut w)?;
+        write_evaluations(&c.val_eval_k, &mut w)?;
+        write_evaluations(&c.row_eval_b, &mut w)?;
+        write_evaluations(&c.col_eval_b, &mut w)?;
+        write_evaluations(&c.val_eval_b, &mut w)?;
+        write_evaluations(&c.rc_eval_b, &mut w)?;
         Ok(())
     }
 
-    let index = unsafe { & *index };
+    let index = unsafe { &*index };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut w = BufWriter::new(File::create(path).unwrap());
 
-    let t : IoResult<()> = (|| {
+    let t: IoResult<()> = (|| {
         write_evaluation_domains(&index.domains, &mut w)?;
 
         for c in index.compiled.iter() {
@@ -1382,7 +1451,7 @@ pub extern "C" fn zexe_bn382_fp_index_write<'a>(
 
 #[no_mangle]
 pub extern "C" fn zexe_bn382_fp_index_read<'a>(
-    srs : *const URS<Bn_382>,
+    srs: *const URS<Bn_382>,
     a: *const Vec<(Vec<usize>, Vec<Fp>)>,
     b: *const Vec<(Vec<usize>, Vec<Fp>)>,
     c: *const Vec<(Vec<usize>, Vec<Fp>)>,
@@ -1406,7 +1475,7 @@ pub extern "C" fn zexe_bn382_fp_index_read<'a>(
         let row_comm = G1Affine::read(&mut r)?;
         let val_comm = G1Affine::read(&mut r)?;
         let rc_comm = G1Affine::read(&mut r)?;
-        let rc  = read_dense_polynomial(&mut r)?;
+        let rc = read_dense_polynomial(&mut r)?;
         let row = read_dense_polynomial(&mut r)?;
         let col = read_dense_polynomial(&mut r)?;
         let val = read_dense_polynomial(&mut r)?;
@@ -1416,33 +1485,36 @@ pub extern "C" fn zexe_bn382_fp_index_read<'a>(
         let row_eval_b = read_evaluations(&mut r)?;
         let col_eval_b = read_evaluations(&mut r)?;
         let val_eval_b = read_evaluations(&mut r)?;
-        let rc_eval_b  = read_evaluations(&mut r)?;
+        let rc_eval_b = read_evaluations(&mut r)?;
 
         Ok(marlin_protocol_pairing::compiled::Compiled {
             constraints,
-            col_comm   ,
-            row_comm   ,
-            val_comm   ,
-            rc_comm    ,
-            rc         ,
-            row        ,
-            col        ,
-            val        ,
-            row_eval_k ,
-            col_eval_k ,
-            val_eval_k ,
-            row_eval_b ,
-            col_eval_b ,
-            val_eval_b ,
-            rc_eval_b   })
+            col_comm,
+            row_comm,
+            val_comm,
+            rc_comm,
+            rc,
+            row,
+            col,
+            val,
+            row_eval_k,
+            col_eval_k,
+            val_eval_k,
+            row_eval_b,
+            col_eval_b,
+            val_eval_b,
+            rc_eval_b,
+        })
     }
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut r = BufReader::new(File::open(path).unwrap());
 
     let srs = unsafe { &*srs };
 
-    let t : IoResult<_> = (|| {
+    let t: IoResult<_> = (|| {
         let domains = read_evaluation_domains(&mut r)?;
 
         let c0 = read_compiled(public_inputs, domains, a, &mut r)?;
@@ -1459,7 +1531,7 @@ pub extern "C" fn zexe_bn382_fp_index_read<'a>(
             fr_sponge_params: oracle::bn_382::fp::params(),
             fq_sponge_params: oracle::bn_382::fq::params(),
             endo_q,
-            endo_r
+            endo_r,
         })
     })();
     Box::into_raw(Box::new(t.unwrap()))
@@ -1495,19 +1567,14 @@ pub extern "C" fn zexe_bn382_g1_add(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g1_double(
-    x: *const G1Projective,
-) -> *const G1Projective {
+pub extern "C" fn zexe_bn382_g1_double(x: *const G1Projective) -> *const G1Projective {
     let x_ = unsafe { &(*x) };
     let ret = x_.double();
     return Box::into_raw(Box::new(ret));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g1_scale(
-    x: *const G1Projective,
-    s: *const Fp,
-) -> *const G1Projective {
+pub extern "C" fn zexe_bn382_g1_scale(x: *const G1Projective, s: *const Fp) -> *const G1Projective {
     let x_ = unsafe { &(*x) };
     let s_ = unsafe { &(*s) };
     let ret = (*x_).mul(*s_);
@@ -1557,10 +1624,7 @@ pub extern "C" fn zexe_bn382_g1_of_affine_coordinates(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g1_affine_create(
-    x: *const Fq,
-    y: *const Fq
-    ) -> *const G1Affine {
+pub extern "C" fn zexe_bn382_g1_affine_create(x: *const Fq, y: *const Fq) -> *const G1Affine {
     let x = (unsafe { *x }).clone();
     let y = (unsafe { *y }).clone();
     Box::into_raw(Box::new(G1Affine::new(x, y, false)))
@@ -1603,7 +1667,10 @@ pub extern "C" fn zexe_bn382_g1_affine_vector_length(v: *const Vec<G1Affine>) ->
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g1_affine_vector_emplace_back(v: *mut Vec<G1Affine>, x: *const G1Affine) {
+pub extern "C" fn zexe_bn382_g1_affine_vector_emplace_back(
+    v: *mut Vec<G1Affine>,
+    x: *const G1Affine,
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(*x_);
@@ -1625,16 +1692,14 @@ pub extern "C" fn zexe_bn382_g1_affine_vector_delete(v: *mut Vec<G1Affine>) {
 // Fq sponge stubs
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_sponge_params_create(
-) -> *mut poseidon::ArithmeticSpongeParams<Fq> {
+pub extern "C" fn zexe_bn382_fq_sponge_params_create() -> *mut poseidon::ArithmeticSpongeParams<Fq>
+{
     let ret = oracle::bn_382::fq::params();
     return Box::into_raw(Box::new(ret));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_fq_sponge_params_delete(
-    x: *mut poseidon::ArithmeticSpongeParams<Fq>,
-) {
+pub extern "C" fn zexe_bn382_fq_sponge_params_delete(x: *mut poseidon::ArithmeticSpongeParams<Fq>) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
@@ -1676,22 +1741,22 @@ pub extern "C" fn zexe_bn382_fq_sponge_squeeze(
 
 // G1 affine pair#[no_mangle]
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g1_affine_pair_0(
-    p: *const (G1Affine, G1Affine)) -> *const G1Affine {
-    let (x0, _) = unsafe { *p};
+pub extern "C" fn zexe_bn382_g1_affine_pair_0(p: *const (G1Affine, G1Affine)) -> *const G1Affine {
+    let (x0, _) = unsafe { *p };
     return Box::into_raw(Box::new(x0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g1_affine_pair_1(
-    p: *const (G1Affine, G1Affine)) -> *const G1Affine {
-    let (_, x1) = unsafe { *p};
+pub extern "C" fn zexe_bn382_g1_affine_pair_1(p: *const (G1Affine, G1Affine)) -> *const G1Affine {
+    let (_, x1) = unsafe { *p };
     return Box::into_raw(Box::new(x1.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g1_affine_pair_make(x0 : *const G1Affine, x1 : *const G1Affine)
--> *const (G1Affine, G1Affine) {
+pub extern "C" fn zexe_bn382_g1_affine_pair_make(
+    x0: *const G1Affine,
+    x1: *const G1Affine,
+) -> *const (G1Affine, G1Affine) {
     let res = ((unsafe { *x0 }), (unsafe { *x1 }));
     return Box::into_raw(Box::new(res));
 }
@@ -1707,20 +1772,28 @@ pub extern "C" fn zexe_bn382_g1_affine_pair_vector_create() -> *mut Vec<(G1Affin
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g1_affine_pair_vector_length(v: *const Vec<(G1Affine, G1Affine)>) -> i32 {
+pub extern "C" fn zexe_bn382_g1_affine_pair_vector_length(
+    v: *const Vec<(G1Affine, G1Affine)>,
+) -> i32 {
     let v_ = unsafe { &(*v) };
     return v_.len() as i32;
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g1_affine_pair_vector_emplace_back(v: *mut Vec<(G1Affine, G1Affine)>, x: *const (G1Affine, G1Affine)) {
+pub extern "C" fn zexe_bn382_g1_affine_pair_vector_emplace_back(
+    v: *mut Vec<(G1Affine, G1Affine)>,
+    x: *const (G1Affine, G1Affine),
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(*x_);
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bn382_g1_affine_pair_vector_get(v: *mut Vec<(G1Affine, G1Affine)>, i: u32) -> *mut (G1Affine, G1Affine) {
+pub extern "C" fn zexe_bn382_g1_affine_pair_vector_get(
+    v: *mut Vec<(G1Affine, G1Affine)>,
+    i: u32,
+) -> *mut (G1Affine, G1Affine) {
     let v_ = unsafe { &mut (*v) };
     return Box::into_raw(Box::new((*v_)[i as usize]));
 }

--- a/snarky-bn382/src/lib.rs
+++ b/snarky-bn382/src/lib.rs
@@ -1,30 +1,32 @@
 #![allow(non_snake_case)]
 extern crate libc;
 
-mod common;
 pub mod bn382_dlog;
 pub mod bn382_pairing;
+mod common;
 pub mod common;
 pub mod tweedledee;
-pub mod tweedledum;
 pub mod tweedledee_plonk;
+pub mod tweedledum;
 pub mod tweedledum_plonk;
 
 use algebra::{
-    biginteger::{BigInteger, BigInteger384, BigInteger256},
-    bn_382::{
-        fp::{Fp, },
-    },
+    biginteger::{BigInteger, BigInteger256, BigInteger384},
+    bn_382::fp::Fp,
 };
 
 use num_bigint::BigUint;
-use oracle::{self, poseidon, poseidon::{Sponge, MarlinSpongeConstants as SC}};
+use oracle::{
+    self, poseidon,
+    poseidon::{MarlinSpongeConstants as SC, Sponge},
+};
 
 // Bigint stubs
 
 const BIGINT384_NUM_BITS: i32 = 384;
 const BIGINT384_LIMB_BITS: i32 = 64;
-const BIGINT384_NUM_LIMBS: i32 = (BIGINT384_NUM_BITS + BIGINT384_LIMB_BITS - 1) / BIGINT384_LIMB_BITS;
+const BIGINT384_NUM_LIMBS: i32 =
+    (BIGINT384_NUM_BITS + BIGINT384_LIMB_BITS - 1) / BIGINT384_LIMB_BITS;
 const BIGINT384_NUM_BYTES: usize = (BIGINT384_NUM_LIMBS as usize) * 8;
 
 fn bigint_of_biginteger384(x: &BigInteger384) -> BigUint {
@@ -106,10 +108,7 @@ pub extern "C" fn zexe_bigint384_of_numeral(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bigint384_compare(
-    x: *const BigInteger384,
-    y: *const BigInteger384,
-) -> u8 {
+pub extern "C" fn zexe_bigint384_compare(x: *const BigInteger384, y: *const BigInteger384) -> u8 {
     let _x = unsafe { &(*x) };
     let _y = unsafe { &(*y) };
     if _x < _y {
@@ -158,7 +157,8 @@ pub extern "C" fn zexe_bigint384_find_wnaf(
 
 const BIGINT256_NUM_BITS: i32 = 256;
 const BIGINT256_LIMB_BITS: i32 = 64;
-const BIGINT256_NUM_LIMBS: i32 = (BIGINT256_NUM_BITS + BIGINT256_LIMB_BITS - 1) / BIGINT256_LIMB_BITS;
+const BIGINT256_NUM_LIMBS: i32 =
+    (BIGINT256_NUM_BITS + BIGINT256_LIMB_BITS - 1) / BIGINT256_LIMB_BITS;
 const BIGINT256_NUM_BYTES: usize = (BIGINT256_NUM_LIMBS as usize) * 8;
 
 fn bigint_of_biginteger256(x: &BigInteger256) -> BigUint {
@@ -240,10 +240,7 @@ pub extern "C" fn zexe_bigint256_of_numeral(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_bigint256_compare(
-    x: *const BigInteger256,
-    y: *const BigInteger256,
-) -> u8 {
+pub extern "C" fn zexe_bigint256_compare(x: *const BigInteger256, y: *const BigInteger256) -> u8 {
     let _x = unsafe { &(*x) };
     let _y = unsafe { &(*y) };
     if _x < _y {
@@ -341,4 +338,3 @@ pub extern "C" fn camlsnark_bn382_fp_sponge_squeeze(
     let ret = sponge.squeeze(params);
     Box::into_raw(Box::new(ret))
 }
-

--- a/snarky-bn382/src/tweedledee.rs
+++ b/snarky-bn382/src/tweedledee.rs
@@ -1,53 +1,54 @@
 use crate::common::*;
 use algebra::{
-    ToBytes, FromBytes, One, Zero,
-    biginteger::{BigInteger256 as BigInteger},
+    biginteger::BigInteger256 as BigInteger,
+    curves::{AffineCurve, ProjectiveCurve},
+    fields::{Field, FpParameters, PrimeField, SquareRootField},
     tweedle::{
-        dee::{Affine as GAffine, Projective as GProjective},
         dee::TweedledeeParameters,
-        fp::{Fp, },
+        dee::{Affine as GAffine, Projective as GProjective},
+        fp::Fp,
         fq::{Fq, FqParameters as Fq_params},
     },
-    curves::{
-        AffineCurve, ProjectiveCurve,
-    },
-    fields::{
-        Field, FpParameters, PrimeField, SquareRootField,
-    },
-    UniformRand,
+    FromBytes, One, ToBytes, UniformRand, Zero,
 };
 
 use marlin_circuits::domains::EvaluationDomains;
 
-use ff_fft::{Evaluations, DensePolynomial, EvaluationDomain, Radix2EvaluationDomain as Domain};
+use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as Domain};
 
 use oracle::{
     self,
+    poseidon::MarlinSpongeConstants,
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
-    poseidon::{MarlinSpongeConstants},
 };
 
 use rand::rngs::StdRng;
 use rand_core;
 
-use std::os::raw::c_char;
+use groupmap::GroupMap;
 use std::ffi::CStr;
 use std::fs::File;
-use std::io::{Read, Result as IoResult, Write, BufReader, BufWriter};
-use groupmap::GroupMap;
+use std::io::{BufReader, BufWriter, Read, Result as IoResult, Write};
+use std::os::raw::c_char;
 
-use marlin_protocol_dlog::index::{
-    Index as DlogIndex, SRSSpec, SRSValue, VerifierIndex as DlogVerifierIndex,
-};
 use commitment_dlog::{
     commitment::{b_poly_coefficients, product, CommitmentCurve, OpeningProof, PolyComm},
     srs::SRS,
 };
-use marlin_protocol_dlog::prover::{ProofEvaluations as DlogProofEvaluations, ProverProof as DlogProof};
+use marlin_protocol_dlog::index::{
+    Index as DlogIndex, SRSSpec, SRSValue, VerifierIndex as DlogVerifierIndex,
+};
+use marlin_protocol_dlog::prover::{
+    ProofEvaluations as DlogProofEvaluations, ProverProof as DlogProof,
+};
 
 // Fp URS stubs
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_urs_create(depth: usize, public: usize, size: usize) -> *const SRS<GAffine> {
+pub extern "C" fn zexe_tweedle_fp_urs_create(
+    depth: usize,
+    public: usize,
+    size: usize,
+) -> *const SRS<GAffine> {
     Box::into_raw(Box::new(SRS::create(depth, public, size)))
 }
 
@@ -68,7 +69,9 @@ pub extern "C" fn zexe_tweedle_fp_urs_write(urs: *mut SRS<GAffine>, path: *mut c
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_urs_read(path: *mut c_char) -> *const SRS<GAffine> {
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let file = BufReader::new(File::open(path).unwrap());
     let res = SRS::<GAffine>::read(file).unwrap();
     return Box::into_raw(Box::new(res));
@@ -76,14 +79,16 @@ pub extern "C" fn zexe_tweedle_fp_urs_read(path: *mut c_char) -> *const SRS<GAff
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_urs_lagrange_commitment(
-    urs : *const SRS<GAffine>,
-    domain_size : usize,
-    i: usize)
--> *const PolyComm<GAffine> {
+    urs: *const SRS<GAffine>,
+    domain_size: usize,
+    i: usize,
+) -> *const PolyComm<GAffine> {
     let urs = unsafe { &*urs };
     let x_domain = EvaluationDomain::<Fp>::new(domain_size).unwrap();
 
-    let evals = (0..domain_size).map(|j| if i == j { Fp::one() } else { Fp::zero() }).collect();
+    let evals = (0..domain_size)
+        .map(|j| if i == j { Fp::one() } else { Fp::zero() })
+        .collect();
     let p = Evaluations::<Fp>::from_vec_and_domain(evals, x_domain).interpolate();
     let res = urs.commit(&p, None);
 
@@ -92,10 +97,10 @@ pub extern "C" fn zexe_tweedle_fp_urs_lagrange_commitment(
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_urs_commit_evaluations(
-    urs : *const SRS<GAffine>,
-    domain_size : usize,
-    evals : *const Vec<Fp>)
--> *const PolyComm<GAffine> {
+    urs: *const SRS<GAffine>,
+    domain_size: usize,
+    evals: *const Vec<Fp>,
+) -> *const PolyComm<GAffine> {
     let urs = unsafe { &*urs };
     let x_domain = EvaluationDomain::<Fp>::new(domain_size).unwrap();
 
@@ -108,14 +113,14 @@ pub extern "C" fn zexe_tweedle_fp_urs_commit_evaluations(
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_urs_b_poly_commitment(
-    urs : *const SRS<GAffine>,
-    chals : *const Vec<Fp>)
--> *const PolyComm<GAffine> {
-    let chals = unsafe { & *chals };
+    urs: *const SRS<GAffine>,
+    chals: *const Vec<Fp>,
+) -> *const PolyComm<GAffine> {
+    let chals = unsafe { &*chals };
     let urs = unsafe { &*urs };
 
     let s0 = product(chals.iter().map(|x| *x)).inverse().unwrap();
-    let chal_squareds : Vec<Fp> = chals.iter().map(|x| x.square()).collect();
+    let chal_squareds: Vec<Fp> = chals.iter().map(|x| x.square()).collect();
     let coeffs = b_poly_coefficients(s0, &chal_squareds);
     let p = DensePolynomial::<Fp>::from_coefficients_vec(coeffs);
     let g = urs.commit(&p, None);
@@ -124,9 +129,7 @@ pub extern "C" fn zexe_tweedle_fp_urs_b_poly_commitment(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_urs_h(
-    urs : *const SRS<GAffine>, )
--> *const GAffine {
+pub extern "C" fn zexe_tweedle_fp_urs_h(urs: *const SRS<GAffine>) -> *const GAffine {
     let urs = unsafe { &*urs };
     let res = urs.h;
     Box::into_raw(Box::new(res))
@@ -134,13 +137,17 @@ pub extern "C" fn zexe_tweedle_fp_urs_h(
 
 // Fp index stubs
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_index_domain_h_size<'a>(i : *const DlogIndex<'a, GAffine>) -> usize {
-    (unsafe { & *i }).domains.h.size()
+pub extern "C" fn zexe_tweedle_fp_index_domain_h_size<'a>(
+    i: *const DlogIndex<'a, GAffine>,
+) -> usize {
+    (unsafe { &*i }).domains.h.size()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_index_domain_k_size<'a>(i : *const DlogIndex<'a, GAffine>) -> usize {
-    (unsafe { & *i }).domains.k.size()
+pub extern "C" fn zexe_tweedle_fp_index_domain_k_size<'a>(
+    i: *const DlogIndex<'a, GAffine>,
+) -> usize {
+    (unsafe { &*i }).domains.k.size()
 }
 
 #[no_mangle]
@@ -150,7 +157,7 @@ pub extern "C" fn zexe_tweedle_fp_index_create<'a>(
     c: *mut Vec<(Vec<usize>, Vec<Fp>)>,
     vars: usize,
     public_inputs: usize,
-    srs : *mut SRS<GAffine>
+    srs: *mut SRS<GAffine>,
 ) -> *mut DlogIndex<'a, GAffine> {
     assert!(public_inputs > 0);
 
@@ -161,7 +168,11 @@ pub extern "C" fn zexe_tweedle_fp_index_create<'a>(
 
     let num_constraints = a.len();
 
-    let m = if num_constraints > vars { num_constraints } else { vars };
+    let m = if num_constraints > vars {
+        num_constraints
+    } else {
+        vars
+    };
 
     let h_group_size = Domain::<Fp>::compute_size_of_domain(m).unwrap();
     let h_to_x_ratio = {
@@ -190,33 +201,30 @@ pub extern "C" fn zexe_tweedle_fp_index_delete(x: *mut DlogIndex<GAffine>) {
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_index_nonzero_entries(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_tweedle_fp_index_nonzero_entries(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
-    index.compiled.iter().map(|x| x.constraints.nnz()).max().unwrap()
+    index
+        .compiled
+        .iter()
+        .map(|x| x.constraints.nnz())
+        .max()
+        .unwrap()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_index_max_degree(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_tweedle_fp_index_max_degree(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
     index.srs.get_ref().max_degree()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_index_num_variables(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_tweedle_fp_index_num_variables(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
     index.compiled[0].constraints.shape().0
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_index_public_inputs(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_tweedle_fp_index_public_inputs(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
     index.public_inputs
 }
@@ -238,22 +246,24 @@ pub extern "C" fn zexe_tweedle_fp_index_write<'a>(
         write_dense_polynomial(&c.row, &mut w)?;
         write_dense_polynomial(&c.col, &mut w)?;
         write_dense_polynomial(&c.val, &mut w)?;
-        write_evaluations(& c.row_eval_k, &mut w)?;
-        write_evaluations(& c.col_eval_k, &mut w)?;
-        write_evaluations(& c.val_eval_k, &mut w)?;
-        write_evaluations(& c.row_eval_b, &mut w)?;
-        write_evaluations(& c.col_eval_b, &mut w)?;
-        write_evaluations(& c.val_eval_b, &mut w)?;
-        write_evaluations(& c.rc_eval_b , &mut w)?;
+        write_evaluations(&c.row_eval_k, &mut w)?;
+        write_evaluations(&c.col_eval_k, &mut w)?;
+        write_evaluations(&c.val_eval_k, &mut w)?;
+        write_evaluations(&c.row_eval_b, &mut w)?;
+        write_evaluations(&c.col_eval_b, &mut w)?;
+        write_evaluations(&c.val_eval_b, &mut w)?;
+        write_evaluations(&c.rc_eval_b, &mut w)?;
         Ok(())
     }
 
-    let index = unsafe { & *index };
+    let index = unsafe { &*index };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut w = BufWriter::new(File::create(path).unwrap());
 
-    let t : IoResult<()> = (|| {
+    let t: IoResult<()> = (|| {
         write_evaluation_domains(&index.domains, &mut w)?;
 
         for c in index.compiled.iter() {
@@ -268,7 +278,7 @@ pub extern "C" fn zexe_tweedle_fp_index_write<'a>(
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_index_read<'a>(
-    srs : *const SRS<GAffine>,
+    srs: *const SRS<GAffine>,
     a: *const Vec<(Vec<usize>, Vec<Fp>)>,
     b: *const Vec<(Vec<usize>, Vec<Fp>)>,
     c: *const Vec<(Vec<usize>, Vec<Fp>)>,
@@ -291,8 +301,8 @@ pub extern "C" fn zexe_tweedle_fp_index_read<'a>(
         let col_comm = read_poly_comm(&mut r)?;
         let row_comm = read_poly_comm(&mut r)?;
         let val_comm = read_poly_comm(&mut r)?;
-        let rc_comm =  read_poly_comm(&mut r)?;
-        let rc  = read_dense_polynomial(&mut r)?;
+        let rc_comm = read_poly_comm(&mut r)?;
+        let rc = read_dense_polynomial(&mut r)?;
         let row = read_dense_polynomial(&mut r)?;
         let col = read_dense_polynomial(&mut r)?;
         let val = read_dense_polynomial(&mut r)?;
@@ -302,33 +312,36 @@ pub extern "C" fn zexe_tweedle_fp_index_read<'a>(
         let row_eval_b = read_evaluations(&mut r)?;
         let col_eval_b = read_evaluations(&mut r)?;
         let val_eval_b = read_evaluations(&mut r)?;
-        let rc_eval_b  = read_evaluations(&mut r)?;
+        let rc_eval_b = read_evaluations(&mut r)?;
 
         Ok(marlin_protocol_dlog::compiled::Compiled {
             constraints,
-            col_comm   ,
-            row_comm   ,
-            val_comm   ,
-            rc_comm    ,
-            rc         ,
-            row        ,
-            col        ,
-            val        ,
-            row_eval_k ,
-            col_eval_k ,
-            val_eval_k ,
-            row_eval_b ,
-            col_eval_b ,
-            val_eval_b ,
-            rc_eval_b   })
+            col_comm,
+            row_comm,
+            val_comm,
+            rc_comm,
+            rc,
+            row,
+            col,
+            val,
+            row_eval_k,
+            col_eval_k,
+            val_eval_k,
+            row_eval_b,
+            col_eval_b,
+            val_eval_b,
+            rc_eval_b,
+        })
     }
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut r = BufReader::new(File::open(path).unwrap());
 
     let srs = unsafe { &*srs };
 
-    let t : IoResult<_> = (|| {
+    let t: IoResult<_> = (|| {
         let domains = read_evaluation_domains(&mut r)?;
 
         let c0 = read_compiled(public_inputs, domains, a, &mut r)?;
@@ -337,7 +350,7 @@ pub extern "C" fn zexe_tweedle_fp_index_read<'a>(
 
         let public_inputs = u64::read(&mut r)? as usize;
 
-        Ok( DlogIndex::<GAffine> {
+        Ok(DlogIndex::<GAffine> {
             compiled: [c0, c1, c2],
             domains,
             public_inputs,
@@ -354,16 +367,16 @@ pub extern "C" fn zexe_tweedle_fp_index_read<'a>(
 // Fp verifier index stubs
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_create(
-    index: *const DlogIndex<GAffine>
+    index: *const DlogIndex<GAffine>,
 ) -> *const DlogVerifierIndex<GAffine> {
-    Box::into_raw(Box::new(unsafe {&(*index)}.verifier_index()))
+    Box::into_raw(Box::new(unsafe { &(*index) }.verifier_index()))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_urs<'a>(
-    index: *const DlogVerifierIndex<'a, GAffine>
+    index: *const DlogVerifierIndex<'a, GAffine>,
 ) -> *const SRS<GAffine> {
-    let index = unsafe { & *index };
+    let index = unsafe { &*index };
     let urs = index.srs.get_ref().clone();
     Box::into_raw(Box::new(urs))
 }
@@ -391,9 +404,10 @@ pub extern "C" fn zexe_tweedle_fp_verifier_index_make<'a>(
     val_c: *const PolyComm<GAffine>,
     rc_c: *const PolyComm<GAffine>,
 ) -> *const DlogVerifierIndex<'a, GAffine> {
-    let srs : SRS<GAffine> = (unsafe { &*urs }).clone();
+    let srs: SRS<GAffine> = (unsafe { &*urs }).clone();
     let index = DlogVerifierIndex::<GAffine> {
-        domains: EvaluationDomains::create(variables, constraints, public_inputs, nonzero_entries).unwrap(),
+        domains: EvaluationDomains::create(variables, constraints, public_inputs, nonzero_entries)
+            .unwrap(),
         matrix_commitments: [
             marlin_protocol_dlog::index::MatrixValues {
                 row: (unsafe { &*row_a }).clone(),
@@ -424,22 +438,23 @@ pub extern "C" fn zexe_tweedle_fp_verifier_index_make<'a>(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_verifier_index_delete(
-    x: *mut DlogVerifierIndex<GAffine>
-) {
+pub extern "C" fn zexe_tweedle_fp_verifier_index_delete(x: *mut DlogVerifierIndex<GAffine>) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_write<'a>(
-    index : *const DlogVerifierIndex<GAffine>,
-    path: *const c_char) {
-    let index = unsafe { & *index };
+    index: *const DlogVerifierIndex<GAffine>,
+    path: *const c_char,
+) {
+    let index = unsafe { &*index };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut w = BufWriter::new(File::create(path).unwrap());
 
-    let t : IoResult<()> = (|| {
+    let t: IoResult<()> = (|| {
         for c in index.matrix_commitments.iter() {
             write_dlog_matrix_values(c, &mut w)?;
         }
@@ -453,14 +468,17 @@ pub extern "C" fn zexe_tweedle_fp_verifier_index_write<'a>(
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_read<'a>(
-    srs : *const SRS<GAffine>,
-    path: *const c_char) -> *const DlogVerifierIndex<'a, GAffine> {
+    srs: *const SRS<GAffine>,
+    path: *const c_char,
+) -> *const DlogVerifierIndex<'a, GAffine> {
     let srs = unsafe { &*srs };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut r = BufReader::new(File::open(path).unwrap());
 
-    let t : IoResult<_> = (|| {
+    let t: IoResult<_> = (|| {
         let m0 = read_dlog_matrix_values(&mut r)?;
         let m1 = read_dlog_matrix_values(&mut r)?;
         let m2 = read_dlog_matrix_values(&mut r)?;
@@ -484,84 +502,108 @@ pub extern "C" fn zexe_tweedle_fp_verifier_index_read<'a>(
 pub extern "C" fn zexe_tweedle_fp_verifier_index_a_row_comm(
     index: *const DlogVerifierIndex<GAffine>,
 ) -> *const PolyComm<GAffine> {
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].row }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_a_col_comm(
     index: *const DlogVerifierIndex<GAffine>,
 ) -> *const PolyComm<GAffine> {
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].col }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_a_val_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].val }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_a_rc_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].rc }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].rc }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_b_row_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].row }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_b_col_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].col }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_b_val_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].val }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_b_rc_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].rc }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].rc }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_c_row_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].row }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_c_col_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].col }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_c_val_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].val }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_verifier_index_c_rc_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].rc }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].rc }).clone(),
+    ))
 }
 
 // Fp stubs
@@ -909,9 +951,7 @@ pub extern "C" fn zexe_tweedle_dee_add(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dee_double(
-    x: *const GProjective,
-) -> *const GProjective {
+pub extern "C" fn zexe_tweedle_dee_double(x: *const GProjective) -> *const GProjective {
     let x_ = unsafe { &(*x) };
     let ret = x_.double();
     return Box::into_raw(Box::new(ret));
@@ -971,10 +1011,7 @@ pub extern "C" fn zexe_tweedle_dee_of_affine_coordinates(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dee_affine_create(
-    x: *const Fq,
-    y: *const Fq
-    ) -> *const GAffine {
+pub extern "C" fn zexe_tweedle_dee_affine_create(x: *const Fq, y: *const Fq) -> *const GAffine {
     let x = (unsafe { *x }).clone();
     let y = (unsafe { *y }).clone();
     Box::into_raw(Box::new(GAffine::new(x, y, false)))
@@ -1005,22 +1042,22 @@ pub extern "C" fn zexe_tweedle_dee_affine_delete(x: *mut GAffine) {
 
 // G affine pair
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dee_affine_pair_0(
-    p: *const (GAffine, GAffine)) -> *const GAffine {
-    let (x0, _) = unsafe { *p};
+pub extern "C" fn zexe_tweedle_dee_affine_pair_0(p: *const (GAffine, GAffine)) -> *const GAffine {
+    let (x0, _) = unsafe { *p };
     return Box::into_raw(Box::new(x0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dee_affine_pair_1(
-    p: *const (GAffine, GAffine)) -> *const GAffine {
-    let (_, x1) = unsafe { *p};
+pub extern "C" fn zexe_tweedle_dee_affine_pair_1(p: *const (GAffine, GAffine)) -> *const GAffine {
+    let (_, x1) = unsafe { *p };
     return Box::into_raw(Box::new(x1.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dee_affine_pair_make(x0 : *const GAffine, x1 : *const GAffine)
--> *const (GAffine, GAffine) {
+pub extern "C" fn zexe_tweedle_dee_affine_pair_make(
+    x0: *const GAffine,
+    x1: *const GAffine,
+) -> *const (GAffine, GAffine) {
     let res = ((unsafe { *x0 }), (unsafe { *x1 }));
     return Box::into_raw(Box::new(res));
 }
@@ -1036,20 +1073,28 @@ pub extern "C" fn zexe_tweedle_dee_affine_pair_vector_create() -> *mut Vec<(GAff
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dee_affine_pair_vector_length(v: *const Vec<(GAffine, GAffine)>) -> i32 {
+pub extern "C" fn zexe_tweedle_dee_affine_pair_vector_length(
+    v: *const Vec<(GAffine, GAffine)>,
+) -> i32 {
     let v_ = unsafe { &(*v) };
     return v_.len() as i32;
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dee_affine_pair_vector_emplace_back(v: *mut Vec<(GAffine, GAffine)>, x: *const (GAffine, GAffine)) {
+pub extern "C" fn zexe_tweedle_dee_affine_pair_vector_emplace_back(
+    v: *mut Vec<(GAffine, GAffine)>,
+    x: *const (GAffine, GAffine),
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(*x_);
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dee_affine_pair_vector_get(v: *mut Vec<(GAffine, GAffine)>, i: u32) -> *mut (GAffine, GAffine) {
+pub extern "C" fn zexe_tweedle_dee_affine_pair_vector_get(
+    v: *mut Vec<(GAffine, GAffine)>,
+    i: u32,
+) -> *mut (GAffine, GAffine) {
     let v_ = unsafe { &mut (*v) };
     return Box::into_raw(Box::new((*v_)[i as usize]));
 }
@@ -1074,7 +1119,10 @@ pub extern "C" fn zexe_tweedle_dee_affine_vector_length(v: *const Vec<GAffine>) 
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dee_affine_vector_emplace_back(v: *mut Vec<GAffine>, x: *const GAffine) {
+pub extern "C" fn zexe_tweedle_dee_affine_vector_emplace_back(
+    v: *mut Vec<GAffine>,
+    x: *const GAffine,
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(*x_);
@@ -1107,9 +1155,8 @@ pub extern "C" fn zexe_tweedle_fp_oracles_create(
     let index = unsafe { &(*index) };
     let proof = unsafe { &(*proof) };
 
-    let x_hat = 
-        evals_from_coeffs(proof.public.clone(), index.domains.x).interpolate();
-        // TODO: Should have no degree bound when we add the correct degree bound method
+    let x_hat = evals_from_coeffs(proof.public.clone(), index.domains.x).interpolate();
+    // TODO: Should have no degree bound when we add the correct degree bound method
     let x_hat_comm = index.srs.get_ref().commit(&x_hat, None);
 
     let (mut sponge, o) = proof
@@ -1118,97 +1165,88 @@ pub extern "C" fn zexe_tweedle_fp_oracles_create(
         );
     let opening_prechallenges = proof.proof.prechallenges(&mut sponge);
 
-    return Box::into_raw(Box::new(FpOracles { o, opening_prechallenges }));
+    return Box::into_raw(Box::new(FpOracles {
+        o,
+        opening_prechallenges,
+    }));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_oracles_opening_prechallenges(
-    oracles: *const FpOracles
+    oracles: *const FpOracles,
 ) -> *const Vec<Fp> {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).opening_prechallenges.iter().map(|x| x.0).collect() ));
+    return Box::into_raw(Box::new(
+        (unsafe { &(*oracles) })
+            .opening_prechallenges
+            .iter()
+            .map(|x| x.0)
+            .collect(),
+    ));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_oracles_alpha(
-    oracles: *const FpOracles
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.alpha.clone() ));
+pub extern "C" fn zexe_tweedle_fp_oracles_alpha(oracles: *const FpOracles) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.alpha.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_oracles_eta_a(
-    oracles: *const FpOracles,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.eta_a.clone() ));
+pub extern "C" fn zexe_tweedle_fp_oracles_eta_a(oracles: *const FpOracles) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.eta_a.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_oracles_eta_b(
-    oracles: *const FpOracles,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.eta_b.clone() ));
+pub extern "C" fn zexe_tweedle_fp_oracles_eta_b(oracles: *const FpOracles) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.eta_b.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_oracles_eta_c(
-    oracles: *const FpOracles,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.eta_c.clone() ));
+pub extern "C" fn zexe_tweedle_fp_oracles_eta_c(oracles: *const FpOracles) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.eta_c.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_oracles_beta1(
-    oracles: *const FpOracles,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.beta[0].0.clone() ));
+pub extern "C" fn zexe_tweedle_fp_oracles_beta1(oracles: *const FpOracles) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.beta[0].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_oracles_beta2(
-    oracles: *const FpOracles,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.beta[1].0.clone() ));
+pub extern "C" fn zexe_tweedle_fp_oracles_beta2(oracles: *const FpOracles) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.beta[1].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_oracles_beta3(
-    oracles: *const FpOracles,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.beta[2].0.clone() ));
+pub extern "C" fn zexe_tweedle_fp_oracles_beta3(oracles: *const FpOracles) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.beta[2].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_oracles_polys(
-    oracles: *const FpOracles,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.polys.0.clone() ));
+pub extern "C" fn zexe_tweedle_fp_oracles_polys(oracles: *const FpOracles) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.polys.0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_oracles_evals(
-    oracles: *const FpOracles,
-) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.evals.0.clone() ));
+pub extern "C" fn zexe_tweedle_fp_oracles_evals(oracles: *const FpOracles) -> *const Fp {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.evals.0.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_oracles_x_hat_nocopy(
     oracles: *const FpOracles,
 ) -> *const [Vec<Fp>; 3] {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.x_hat.clone() ));
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.x_hat.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_oracles_digest_before_evaluations(
     oracles: *const FpOracles,
 ) -> *const Fp {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.digest_before_evaluations.clone() ));
+    return Box::into_raw(Box::new(
+        (unsafe { &(*oracles) }).o.digest_before_evaluations.clone(),
+    ));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_oracles_delete(
-    x: *mut FpOracles,
-    ) {
+pub extern "C" fn zexe_tweedle_fp_oracles_delete(x: *mut FpOracles) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
@@ -1219,7 +1257,7 @@ pub extern "C" fn zexe_tweedle_fp_proof_create(
     primary_input: *const Vec<Fp>,
     auxiliary_input: *const Vec<Fp>,
     prev_challenges: *const Vec<Fp>,
-    prev_sgs : *const Vec<GAffine>,
+    prev_sgs: *const Vec<GAffine>,
 ) -> *const DlogProof<GAffine> {
     let index = unsafe { &(*index) };
     let primary_input = unsafe { &(*primary_input) };
@@ -1227,27 +1265,39 @@ pub extern "C" fn zexe_tweedle_fp_proof_create(
 
     let witness = prepare_witness(index.domains, primary_input, auxiliary_input);
 
-    let prev : Vec<(Vec<Fp>, PolyComm<GAffine>)> = {
-        let prev_challenges = unsafe { &*prev_challenges};
+    let prev: Vec<(Vec<Fp>, PolyComm<GAffine>)> = {
+        let prev_challenges = unsafe { &*prev_challenges };
         let prev_sgs = unsafe { &*prev_sgs };
-        if prev_challenges.len() == 0 {Vec::new()} else
-        {
+        if prev_challenges.len() == 0 {
+            Vec::new()
+        } else {
             let challenges_per_sg = prev_challenges.len() / prev_sgs.len();
-            prev_sgs.iter().enumerate().map( |(i, sg)| {
-                (
-                    prev_challenges[(i * challenges_per_sg)..(i+1)*challenges_per_sg].iter().map(|x| *x).collect(),
-                    PolyComm::<GAffine>{unshifted: vec![sg.clone()], shifted: None}
-                )
-            }).collect()
+            prev_sgs
+                .iter()
+                .enumerate()
+                .map(|(i, sg)| {
+                    (
+                        prev_challenges[(i * challenges_per_sg)..(i + 1) * challenges_per_sg]
+                            .iter()
+                            .map(|x| *x)
+                            .collect(),
+                        PolyComm::<GAffine> {
+                            unshifted: vec![sg.clone()],
+                            shifted: None,
+                        },
+                    )
+                })
+                .collect()
         }
     };
-    
+
     let rng = &mut rand_core::OsRng;
 
     let map = <GAffine as CommitmentCurve>::Map::setup();
-    let proof = DlogProof::create::<DefaultFqSponge<TweedledeeParameters, MarlinSpongeConstants>, DefaultFrSponge<Fp, MarlinSpongeConstants>>(
-        &map, &witness, &index, prev, rng,
-    )
+    let proof = DlogProof::create::<
+        DefaultFqSponge<TweedledeeParameters, MarlinSpongeConstants>,
+        DefaultFrSponge<Fp, MarlinSpongeConstants>,
+    >(&map, &witness, &index, prev, rng)
     .unwrap();
 
     return Box::into_raw(Box::new(proof));
@@ -1258,17 +1308,14 @@ pub extern "C" fn zexe_tweedle_fp_proof_verify(
     index: *const DlogVerifierIndex<GAffine>,
     proof: *const DlogProof<GAffine>,
 ) -> bool {
-
     let index = unsafe { &(*index) };
     let proof = unsafe { (*proof).clone() };
     let group_map = <GAffine as CommitmentCurve>::Map::setup();
 
-    DlogProof::verify::<DefaultFqSponge<TweedledeeParameters, MarlinSpongeConstants>, DefaultFrSponge<Fp, MarlinSpongeConstants>>(
-        &group_map,
-        &[proof].to_vec(),
-        &index,
-        &mut rand_core::OsRng
-    )
+    DlogProof::verify::<
+        DefaultFqSponge<TweedledeeParameters, MarlinSpongeConstants>,
+        DefaultFrSponge<Fp, MarlinSpongeConstants>,
+    >(&group_map, &[proof].to_vec(), &index, &mut rand_core::OsRng)
 }
 
 // TODO: Batch verify across different indexes
@@ -1281,65 +1328,72 @@ pub extern "C" fn zexe_tweedle_fp_proof_batch_verify(
     let proofs = unsafe { &(*proofs) };
     let group_map = <GAffine as CommitmentCurve>::Map::setup();
 
-    DlogProof::<GAffine>::verify::<DefaultFqSponge<TweedledeeParameters, MarlinSpongeConstants>, DefaultFrSponge<Fp, MarlinSpongeConstants>>(
-        &group_map,
-        proofs,
-        index,
-        &mut rand_core::OsRng,
-    )
+    DlogProof::<GAffine>::verify::<
+        DefaultFqSponge<TweedledeeParameters, MarlinSpongeConstants>,
+        DefaultFrSponge<Fp, MarlinSpongeConstants>,
+    >(&group_map, proofs, index, &mut rand_core::OsRng)
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_proof_make(
-    primary_input : *const Vec<Fp>,
+    primary_input: *const Vec<Fp>,
 
-    w_comm        : *const PolyComm<GAffine>,
-    za_comm       : *const PolyComm<GAffine>,
-    zb_comm       : *const PolyComm<GAffine>,
-    h1_comm       : *const PolyComm<GAffine>,
-    g1_comm       : *const PolyComm<GAffine>,
-    h2_comm       : *const PolyComm<GAffine>,
-    g2_comm       : *const PolyComm<GAffine>,
-    h3_comm       : *const PolyComm<GAffine>,
-    g3_comm       : *const PolyComm<GAffine>,
+    w_comm: *const PolyComm<GAffine>,
+    za_comm: *const PolyComm<GAffine>,
+    zb_comm: *const PolyComm<GAffine>,
+    h1_comm: *const PolyComm<GAffine>,
+    g1_comm: *const PolyComm<GAffine>,
+    h2_comm: *const PolyComm<GAffine>,
+    g2_comm: *const PolyComm<GAffine>,
+    h3_comm: *const PolyComm<GAffine>,
+    g3_comm: *const PolyComm<GAffine>,
 
-    sigma2        : *const Fp,
-    sigma3        : *const Fp, 
+    sigma2: *const Fp,
+    sigma3: *const Fp,
 
-    lr : *const Vec<(GAffine, GAffine)>,
-    z1 : *const Fp,
-    z2 : *const Fp,
-    delta : *const GAffine,
-    sg : *const GAffine,
+    lr: *const Vec<(GAffine, GAffine)>,
+    z1: *const Fp,
+    z2: *const Fp,
+    delta: *const GAffine,
+    sg: *const GAffine,
 
-    evals0 : *const DlogProofEvaluations<Fp>,
-    evals1 : *const DlogProofEvaluations<Fp>,
-    evals2 : *const DlogProofEvaluations<Fp>,
+    evals0: *const DlogProofEvaluations<Fp>,
+    evals1: *const DlogProofEvaluations<Fp>,
+    evals2: *const DlogProofEvaluations<Fp>,
 
     prev_challenges: *const Vec<Fp>,
-    prev_sgs : *const Vec<GAffine>,
-    ) -> *const DlogProof<GAffine> {
-
+    prev_sgs: *const Vec<GAffine>,
+) -> *const DlogProof<GAffine> {
     let public = unsafe { &(*primary_input) }.clone();
     // public.resize(ceil_pow2(public.len()), Fp::zero());
 
-    let prev : Vec<(Vec<Fp>, PolyComm<GAffine>)> = {
-        let prev_challenges = unsafe { &*prev_challenges};
+    let prev: Vec<(Vec<Fp>, PolyComm<GAffine>)> = {
+        let prev_challenges = unsafe { &*prev_challenges };
         let prev_sgs = unsafe { &*prev_sgs };
-        if prev_challenges.len() == 0 {Vec::new()} else
-        {
+        if prev_challenges.len() == 0 {
+            Vec::new()
+        } else {
             let challenges_per_sg = prev_challenges.len() / prev_sgs.len();
-            prev_sgs.iter().enumerate().map( |(i, sg)| {
-                (
-                    prev_challenges[(i * challenges_per_sg)..(i+1)*challenges_per_sg].iter().map(|x| *x).collect(),
-                    PolyComm::<GAffine>{unshifted: vec![sg.clone()], shifted: None}
-                )
-            }).collect()
+            prev_sgs
+                .iter()
+                .enumerate()
+                .map(|(i, sg)| {
+                    (
+                        prev_challenges[(i * challenges_per_sg)..(i + 1) * challenges_per_sg]
+                            .iter()
+                            .map(|x| *x)
+                            .collect(),
+                        PolyComm::<GAffine> {
+                            unshifted: vec![sg.clone()],
+                            shifted: None,
+                        },
+                    )
+                })
+                .collect()
         }
     };
 
     let res = DlogProof {
-
         prev_challenges: prev,
         proof: OpeningProof {
             lr: (unsafe { &*lr }).clone(),
@@ -1349,20 +1403,24 @@ pub extern "C" fn zexe_tweedle_fp_proof_make(
             sg: (unsafe { *sg }).clone(),
         },
         w_comm: (unsafe { &*w_comm }).clone(),
-        za_comm: (unsafe { &*za_comm }).clone() ,
-        zb_comm: (unsafe { &*zb_comm }).clone() ,
-        h1_comm: (unsafe { &*h1_comm }).clone() ,
+        za_comm: (unsafe { &*za_comm }).clone(),
+        zb_comm: (unsafe { &*zb_comm }).clone(),
+        h1_comm: (unsafe { &*h1_comm }).clone(),
         g1_comm: (unsafe { &*g1_comm }).clone(),
-        h2_comm: (unsafe { &*h2_comm }).clone() ,
+        h2_comm: (unsafe { &*h2_comm }).clone(),
         g2_comm: (unsafe { &*g2_comm }).clone(),
-        h3_comm: (unsafe { &*h3_comm }).clone() ,
+        h3_comm: (unsafe { &*h3_comm }).clone(),
         g3_comm: (unsafe { &*g3_comm }).clone(),
 
         sigma2: (unsafe { *sigma2 }).clone(),
         sigma3: (unsafe { *sigma3 }).clone(),
 
         public,
-        evals: [(unsafe { &*evals0 }).clone(), (unsafe {& *evals1 }).clone(), (unsafe { &*evals2 }).clone(), ],
+        evals: [
+            (unsafe { &*evals0 }).clone(),
+            (unsafe { &*evals1 }).clone(),
+            (unsafe { &*evals2 }).clone(),
+        ],
     };
     return Box::into_raw(Box::new(res));
 }
@@ -1373,55 +1431,73 @@ pub extern "C" fn zexe_tweedle_fp_proof_delete(x: *mut DlogProof<GAffine>) {
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_w_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe { &((*p).w_comm )}).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_w_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).w_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_za_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).za_comm )}).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_za_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).za_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_zb_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).zb_comm )}).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_zb_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).zb_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_h1_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).h1_comm )}).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_h1_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).h1_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_g1_comm_nocopy(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_tweedle_fp_proof_g1_comm_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).g1_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_h2_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).h2_comm )}).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_h2_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).h2_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_g2_comm_nocopy(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_tweedle_fp_proof_g2_comm_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).g2_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_h3_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_tweedle_fp_proof_h3_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).h3_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_g3_comm_nocopy(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_tweedle_fp_proof_g3_comm_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).g3_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1439,13 +1515,17 @@ pub extern "C" fn zexe_tweedle_fp_proof_sigma3(p: *mut DlogProof<GAffine>) -> *c
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_proof(p: *mut DlogProof<GAffine>) -> *const OpeningProof<GAffine> {
+pub extern "C" fn zexe_tweedle_fp_proof_proof(
+    p: *mut DlogProof<GAffine>,
+) -> *const OpeningProof<GAffine> {
     let x = (unsafe { &(*p).proof }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evals_nocopy(p: *mut DlogProof<GAffine>) -> *const [DlogProofEvaluations<Fp>; 3] {
+pub extern "C" fn zexe_tweedle_fp_proof_evals_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const [DlogProofEvaluations<Fp>; 3] {
     let x = (unsafe { &(*p).evals }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1464,14 +1544,20 @@ pub extern "C" fn zexe_tweedle_fp_proof_vector_length(v: *const Vec<DlogProof<GA
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_vector_emplace_back(v: *mut Vec<DlogProof<GAffine>>, x: *const DlogProof<GAffine>) {
+pub extern "C" fn zexe_tweedle_fp_proof_vector_emplace_back(
+    v: *mut Vec<DlogProof<GAffine>>,
+    x: *const DlogProof<GAffine>,
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(x_.clone());
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_vector_get(v: *mut Vec<DlogProof<GAffine>>, i: u32) -> *mut DlogProof<GAffine> {
+pub extern "C" fn zexe_tweedle_fp_proof_vector_get(
+    v: *mut Vec<DlogProof<GAffine>>,
+    i: u32,
+) -> *mut DlogProof<GAffine> {
     let v_ = unsafe { &mut (*v) };
     return Box::into_raw(Box::new((*v_)[i as usize].clone()));
 }
@@ -1492,13 +1578,17 @@ pub extern "C" fn zexe_tweedle_fp_opening_proof_delete(p: *mut OpeningProof<GAff
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_opening_proof_sg(p: *const OpeningProof<GAffine>) -> *const GAffine {
+pub extern "C" fn zexe_tweedle_fp_opening_proof_sg(
+    p: *const OpeningProof<GAffine>,
+) -> *const GAffine {
     let x = (unsafe { &(*p).sg }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_opening_proof_lr(p: *const OpeningProof<GAffine>) -> *const Vec<(GAffine, GAffine)> {
+pub extern "C" fn zexe_tweedle_fp_opening_proof_lr(
+    p: *const OpeningProof<GAffine>,
+) -> *const Vec<(GAffine, GAffine)> {
     let x = (unsafe { &(*p).lr }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1516,7 +1606,9 @@ pub extern "C" fn zexe_tweedle_fp_opening_proof_z2(p: *const OpeningProof<GAffin
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_opening_proof_delta(p: *const OpeningProof<GAffine>) -> *const GAffine {
+pub extern "C" fn zexe_tweedle_fp_opening_proof_delta(
+    p: *const OpeningProof<GAffine>,
+) -> *const GAffine {
     let x = (unsafe { &(*p).delta }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1524,103 +1616,137 @@ pub extern "C" fn zexe_tweedle_fp_opening_proof_delta(p: *const OpeningProof<GAf
 // Fp proof evaluations
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_w(e: *const DlogProofEvaluations<Fp>) -> *const Vec<Fp> {
-    let x = (unsafe { & (*e).w }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_w(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const Vec<Fp> {
+    let x = (unsafe { &(*e).w }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_za(e: *const DlogProofEvaluations<Fp>) -> *const Vec<Fp> {
-    let x = (unsafe { & (*e).za }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_za(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const Vec<Fp> {
+    let x = (unsafe { &(*e).za }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_zb(e: *const DlogProofEvaluations<Fp>) -> *const Vec<Fp> {
-    let x = (unsafe { & (*e).zb }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_zb(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const Vec<Fp> {
+    let x = (unsafe { &(*e).zb }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_h1(e: *const DlogProofEvaluations<Fp>) -> *const Vec<Fp> {
-    let x = (unsafe { & (*e).h1 }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_h1(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const Vec<Fp> {
+    let x = (unsafe { &(*e).h1 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_h2(e: *const DlogProofEvaluations<Fp>) -> *const Vec<Fp> {
-    let x = (unsafe { & (*e).h2 }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_h2(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const Vec<Fp> {
+    let x = (unsafe { &(*e).h2 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_h3(e: *const DlogProofEvaluations<Fp>) -> *const Vec<Fp> {
-    let x = (unsafe { & (*e).h3 }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_h3(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const Vec<Fp> {
+    let x = (unsafe { &(*e).h3 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_g1(e: *const DlogProofEvaluations<Fp>) -> *const Vec<Fp> {
-    let x = (unsafe { & (*e).g1 }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_g1(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const Vec<Fp> {
+    let x = (unsafe { &(*e).g1 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_g2(e: *const DlogProofEvaluations<Fp>) -> *const Vec<Fp> {
-    let x = (unsafe { & (*e).g2 }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_g2(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const Vec<Fp> {
+    let x = (unsafe { &(*e).g2 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_g3(e: *const DlogProofEvaluations<Fp>) -> *const Vec<Fp> {
-    let x = (unsafe { & (*e).g3 }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_g3(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const Vec<Fp> {
+    let x = (unsafe { &(*e).g3 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_row_nocopy(e: *const DlogProofEvaluations<Fp>) -> *const [Vec<Fp>; 3] {
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_row_nocopy(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const [Vec<Fp>; 3] {
     let x = (unsafe { &(*e).row }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_val_nocopy(e: *const DlogProofEvaluations<Fp>) -> *const [Vec<Fp>; 3] {
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_val_nocopy(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const [Vec<Fp>; 3] {
     let x = (unsafe { &(*e).val }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_col_nocopy(e: *const DlogProofEvaluations<Fp>) -> *const [Vec<Fp>; 3] {
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_col_nocopy(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const [Vec<Fp>; 3] {
     let x = (unsafe { &(*e).col }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_rc_nocopy(e: *const DlogProofEvaluations<Fp>) -> *const [Vec<Fp>; 3] {
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_rc_nocopy(
+    e: *const DlogProofEvaluations<Fp>,
+) -> *const [Vec<Fp>; 3] {
     let x = (unsafe { &(*e).rc }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_triple_0(e: *const [DlogProofEvaluations<Fp>; 3]) -> *const DlogProofEvaluations<Fp> {
-    let x = (unsafe { & (*e)[0] }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_triple_0(
+    e: *const [DlogProofEvaluations<Fp>; 3],
+) -> *const DlogProofEvaluations<Fp> {
+    let x = (unsafe { &(*e)[0] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_triple_1(e: *const [DlogProofEvaluations<Fp>; 3]) -> *const DlogProofEvaluations<Fp> {
-    let x = (unsafe { & (*e)[1] }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_triple_1(
+    e: *const [DlogProofEvaluations<Fp>; 3],
+) -> *const DlogProofEvaluations<Fp> {
+    let x = (unsafe { &(*e)[1] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_triple_2(e: *const [DlogProofEvaluations<Fp>; 3]) -> *const DlogProofEvaluations<Fp> {
-    let x = (unsafe { & (*e)[2] }).clone();
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_triple_2(
+    e: *const [DlogProofEvaluations<Fp>; 3],
+) -> *const DlogProofEvaluations<Fp> {
+    let x = (unsafe { &(*e)[2] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_proof_evaluations_triple_delete(x: *mut [DlogProofEvaluations<Fp>; 3]) {
+pub extern "C" fn zexe_tweedle_fp_proof_evaluations_triple_delete(
+    x: *mut [DlogProofEvaluations<Fp>; 3],
+) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
@@ -1650,8 +1776,9 @@ pub extern "C" fn zexe_tweedle_fp_proof_evaluations_make(
 
     rc_0: *const Vec<Fp>,
     rc_1: *const Vec<Fp>,
-    rc_2: *const Vec<Fp>) -> *const DlogProofEvaluations<Fp> {
-    let res : DlogProofEvaluations<Fp> = DlogProofEvaluations {
+    rc_2: *const Vec<Fp>,
+) -> *const DlogProofEvaluations<Fp> {
+    let res: DlogProofEvaluations<Fp> = DlogProofEvaluations {
         w: (unsafe { &*w }).clone(),
         za: (unsafe { &*za }).clone(),
         zb: (unsafe { &*zb }).clone(),
@@ -1661,22 +1788,26 @@ pub extern "C" fn zexe_tweedle_fp_proof_evaluations_make(
         h1: (unsafe { &*h1 }).clone(),
         h2: (unsafe { &*h2 }).clone(),
         h3: (unsafe { &*h3 }).clone(),
-        row:
-            [ (unsafe {&*row_0}).clone(),
-                (unsafe {&*row_1}).clone(),
-                (unsafe {&*row_2}).clone() ],
-        col:
-            [ (unsafe {&*col_0}).clone(),
-                (unsafe {&*col_1}).clone(),
-                (unsafe {&*col_2}).clone() ],
-        val:
-            [ (unsafe {&*val_0}).clone(),
-                (unsafe {&*val_1}).clone(),
-                (unsafe {&*val_2}).clone() ],
-        rc:
-            [ (unsafe {&*rc_0}).clone(),
-                (unsafe {&*rc_1}).clone(),
-                (unsafe {&*rc_2}).clone() ],
+        row: [
+            (unsafe { &*row_0 }).clone(),
+            (unsafe { &*row_1 }).clone(),
+            (unsafe { &*row_2 }).clone(),
+        ],
+        col: [
+            (unsafe { &*col_0 }).clone(),
+            (unsafe { &*col_1 }).clone(),
+            (unsafe { &*col_2 }).clone(),
+        ],
+        val: [
+            (unsafe { &*val_0 }).clone(),
+            (unsafe { &*val_1 }).clone(),
+            (unsafe { &*val_2 }).clone(),
+        ],
+        rc: [
+            (unsafe { &*rc_0 }).clone(),
+            (unsafe { &*rc_1 }).clone(),
+            (unsafe { &*rc_2 }).clone(),
+        ],
     };
 
     return Box::into_raw(Box::new(res));
@@ -1689,33 +1820,39 @@ pub extern "C" fn zexe_tweedle_fp_proof_evaluations_delete(x: *mut DlogProofEval
 
 // fq poly comm
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_poly_comm_unshifted(c: *const PolyComm<GAffine>) -> *const Vec<GAffine> {
-    let c = unsafe {& (*c) };
+pub extern "C" fn zexe_tweedle_fp_poly_comm_unshifted(
+    c: *const PolyComm<GAffine>,
+) -> *const Vec<GAffine> {
+    let c = unsafe { &(*c) };
     return Box::into_raw(Box::new(c.unshifted.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fp_poly_comm_shifted(c: *const PolyComm<GAffine>) -> *const GAffine {
-    let c = unsafe {& (*c) };
+    let c = unsafe { &(*c) };
     match c.shifted {
         Some(g) => Box::into_raw(Box::new(g.clone())),
-        None =>  std::ptr::null()
+        None => std::ptr::null(),
     }
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fp_poly_comm_make
-(
+pub extern "C" fn zexe_tweedle_fp_poly_comm_make(
     unshifted: *const Vec<GAffine>,
-    shifted: *const GAffine
-) -> *const PolyComm<GAffine>
-{
-    let unsh = unsafe {& (*unshifted) };
+    shifted: *const GAffine,
+) -> *const PolyComm<GAffine> {
+    let unsh = unsafe { &(*unshifted) };
 
-    let commitment = PolyComm
-    {
+    let commitment = PolyComm {
         unshifted: unsh.clone(),
-        shifted: if shifted == std::ptr::null() {None} else {Some ({let sh = unsafe {& (*shifted) }; *sh})}
+        shifted: if shifted == std::ptr::null() {
+            None
+        } else {
+            Some({
+                let sh = unsafe { &(*shifted) };
+                *sh
+            })
+        },
     };
 
     Box::into_raw(Box::new(commitment))

--- a/snarky-bn382/src/tweedledum.rs
+++ b/snarky-bn382/src/tweedledum.rs
@@ -1,53 +1,54 @@
 use crate::common::*;
 use algebra::{
-    ToBytes, FromBytes, One, Zero,
-    biginteger::{BigInteger256 as BigInteger},
+    biginteger::BigInteger256 as BigInteger,
+    curves::{AffineCurve, ProjectiveCurve},
+    fields::{Field, FpParameters, PrimeField, SquareRootField},
     tweedle::{
-        dum::{Affine as GAffine, Projective as GProjective},
         dum::TweedledumParameters,
+        dum::{Affine as GAffine, Projective as GProjective},
         fp::{Fp, FpParameters as Fp_params},
-        fq::{Fq},
+        fq::Fq,
     },
-    curves::{
-        AffineCurve, ProjectiveCurve,
-    },
-    fields::{
-        Field, FpParameters, PrimeField, SquareRootField,
-    },
-    UniformRand,
+    FromBytes, One, ToBytes, UniformRand, Zero,
 };
 
 use marlin_circuits::domains::EvaluationDomains;
 
-use ff_fft::{Evaluations, DensePolynomial, EvaluationDomain, Radix2EvaluationDomain as Domain};
+use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as Domain};
 
 use oracle::{
     self,
+    poseidon::MarlinSpongeConstants,
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
-    poseidon::{MarlinSpongeConstants},
 };
 
 use rand::rngs::StdRng;
 use rand_core;
 
-use std::os::raw::c_char;
+use groupmap::GroupMap;
 use std::ffi::CStr;
 use std::fs::File;
-use std::io::{Read, Result as IoResult, Write, BufReader, BufWriter};
-use groupmap::GroupMap;
+use std::io::{BufReader, BufWriter, Read, Result as IoResult, Write};
+use std::os::raw::c_char;
 
-use marlin_protocol_dlog::index::{
-    Index as DlogIndex, SRSSpec, SRSValue, VerifierIndex as DlogVerifierIndex,
-};
 use commitment_dlog::{
     commitment::{b_poly_coefficients, product, CommitmentCurve, OpeningProof, PolyComm},
     srs::SRS,
 };
-use marlin_protocol_dlog::prover::{ProofEvaluations as DlogProofEvaluations, ProverProof as DlogProof};
+use marlin_protocol_dlog::index::{
+    Index as DlogIndex, SRSSpec, SRSValue, VerifierIndex as DlogVerifierIndex,
+};
+use marlin_protocol_dlog::prover::{
+    ProofEvaluations as DlogProofEvaluations, ProverProof as DlogProof,
+};
 
 // Fq URS stubs
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_urs_create(depth: usize, public: usize, size: usize) -> *const SRS<GAffine> {
+pub extern "C" fn zexe_tweedle_fq_urs_create(
+    depth: usize,
+    public: usize,
+    size: usize,
+) -> *const SRS<GAffine> {
     Box::into_raw(Box::new(SRS::create(depth, public, size)))
 }
 
@@ -68,7 +69,9 @@ pub extern "C" fn zexe_tweedle_fq_urs_write(urs: *mut SRS<GAffine>, path: *mut c
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_urs_read(path: *mut c_char) -> *const SRS<GAffine> {
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let file = BufReader::new(File::open(path).unwrap());
     let res = SRS::<GAffine>::read(file).unwrap();
     return Box::into_raw(Box::new(res));
@@ -76,14 +79,16 @@ pub extern "C" fn zexe_tweedle_fq_urs_read(path: *mut c_char) -> *const SRS<GAff
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_urs_lagrange_commitment(
-    urs : *const SRS<GAffine>,
-    domain_size : usize,
-    i: usize)
--> *const PolyComm<GAffine> {
+    urs: *const SRS<GAffine>,
+    domain_size: usize,
+    i: usize,
+) -> *const PolyComm<GAffine> {
     let urs = unsafe { &*urs };
     let x_domain = EvaluationDomain::<Fq>::new(domain_size).unwrap();
 
-    let evals = (0..domain_size).map(|j| if i == j { Fq::one() } else { Fq::zero() }).collect();
+    let evals = (0..domain_size)
+        .map(|j| if i == j { Fq::one() } else { Fq::zero() })
+        .collect();
     let p = Evaluations::<Fq>::from_vec_and_domain(evals, x_domain).interpolate();
     let res = urs.commit(&p, None);
 
@@ -92,10 +97,10 @@ pub extern "C" fn zexe_tweedle_fq_urs_lagrange_commitment(
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_urs_commit_evaluations(
-    urs : *const SRS<GAffine>,
-    domain_size : usize,
-    evals : *const Vec<Fq>)
--> *const PolyComm<GAffine> {
+    urs: *const SRS<GAffine>,
+    domain_size: usize,
+    evals: *const Vec<Fq>,
+) -> *const PolyComm<GAffine> {
     let urs = unsafe { &*urs };
     let x_domain = EvaluationDomain::<Fq>::new(domain_size).unwrap();
 
@@ -108,14 +113,14 @@ pub extern "C" fn zexe_tweedle_fq_urs_commit_evaluations(
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_urs_b_poly_commitment(
-    urs : *const SRS<GAffine>,
-    chals : *const Vec<Fq>)
--> *const PolyComm<GAffine> {
-    let chals = unsafe { & *chals };
+    urs: *const SRS<GAffine>,
+    chals: *const Vec<Fq>,
+) -> *const PolyComm<GAffine> {
+    let chals = unsafe { &*chals };
     let urs = unsafe { &*urs };
 
     let s0 = product(chals.iter().map(|x| *x)).inverse().unwrap();
-    let chal_squareds : Vec<Fq> = chals.iter().map(|x| x.square()).collect();
+    let chal_squareds: Vec<Fq> = chals.iter().map(|x| x.square()).collect();
     let coeffs = b_poly_coefficients(s0, &chal_squareds);
     let p = DensePolynomial::<Fq>::from_coefficients_vec(coeffs);
     let g = urs.commit(&p, None);
@@ -124,9 +129,7 @@ pub extern "C" fn zexe_tweedle_fq_urs_b_poly_commitment(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_urs_h(
-    urs : *const SRS<GAffine>, )
--> *const GAffine {
+pub extern "C" fn zexe_tweedle_fq_urs_h(urs: *const SRS<GAffine>) -> *const GAffine {
     let urs = unsafe { &*urs };
     let res = urs.h;
     Box::into_raw(Box::new(res))
@@ -134,13 +137,17 @@ pub extern "C" fn zexe_tweedle_fq_urs_h(
 
 // Fq index stubs
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_index_domain_h_size<'a>(i : *const DlogIndex<'a, GAffine>) -> usize {
-    (unsafe { & *i }).domains.h.size()
+pub extern "C" fn zexe_tweedle_fq_index_domain_h_size<'a>(
+    i: *const DlogIndex<'a, GAffine>,
+) -> usize {
+    (unsafe { &*i }).domains.h.size()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_index_domain_k_size<'a>(i : *const DlogIndex<'a, GAffine>) -> usize {
-    (unsafe { & *i }).domains.k.size()
+pub extern "C" fn zexe_tweedle_fq_index_domain_k_size<'a>(
+    i: *const DlogIndex<'a, GAffine>,
+) -> usize {
+    (unsafe { &*i }).domains.k.size()
 }
 
 #[no_mangle]
@@ -150,7 +157,7 @@ pub extern "C" fn zexe_tweedle_fq_index_create<'a>(
     c: *mut Vec<(Vec<usize>, Vec<Fq>)>,
     vars: usize,
     public_inputs: usize,
-    srs : *mut SRS<GAffine>
+    srs: *mut SRS<GAffine>,
 ) -> *mut DlogIndex<'a, GAffine> {
     assert!(public_inputs > 0);
 
@@ -161,7 +168,11 @@ pub extern "C" fn zexe_tweedle_fq_index_create<'a>(
 
     let num_constraints = a.len();
 
-    let m = if num_constraints > vars { num_constraints } else { vars };
+    let m = if num_constraints > vars {
+        num_constraints
+    } else {
+        vars
+    };
 
     let h_group_size = Domain::<Fq>::compute_size_of_domain(m).unwrap();
     let h_to_x_ratio = {
@@ -190,33 +201,30 @@ pub extern "C" fn zexe_tweedle_fq_index_delete(x: *mut DlogIndex<GAffine>) {
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_index_nonzero_entries(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_tweedle_fq_index_nonzero_entries(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
-    index.compiled.iter().map(|x| x.constraints.nnz()).max().unwrap()
+    index
+        .compiled
+        .iter()
+        .map(|x| x.constraints.nnz())
+        .max()
+        .unwrap()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_index_max_degree(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_tweedle_fq_index_max_degree(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
     index.srs.get_ref().max_degree()
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_index_num_variables(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_tweedle_fq_index_num_variables(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
     index.compiled[0].constraints.shape().0
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_index_public_inputs(
-    index: *const DlogIndex<GAffine>,
-) -> usize {
+pub extern "C" fn zexe_tweedle_fq_index_public_inputs(index: *const DlogIndex<GAffine>) -> usize {
     let index = unsafe { &*index };
     index.public_inputs
 }
@@ -238,22 +246,24 @@ pub extern "C" fn zexe_tweedle_fq_index_write<'a>(
         write_dense_polynomial(&c.row, &mut w)?;
         write_dense_polynomial(&c.col, &mut w)?;
         write_dense_polynomial(&c.val, &mut w)?;
-        write_evaluations(& c.row_eval_k, &mut w)?;
-        write_evaluations(& c.col_eval_k, &mut w)?;
-        write_evaluations(& c.val_eval_k, &mut w)?;
-        write_evaluations(& c.row_eval_b, &mut w)?;
-        write_evaluations(& c.col_eval_b, &mut w)?;
-        write_evaluations(& c.val_eval_b, &mut w)?;
-        write_evaluations(& c.rc_eval_b , &mut w)?;
+        write_evaluations(&c.row_eval_k, &mut w)?;
+        write_evaluations(&c.col_eval_k, &mut w)?;
+        write_evaluations(&c.val_eval_k, &mut w)?;
+        write_evaluations(&c.row_eval_b, &mut w)?;
+        write_evaluations(&c.col_eval_b, &mut w)?;
+        write_evaluations(&c.val_eval_b, &mut w)?;
+        write_evaluations(&c.rc_eval_b, &mut w)?;
         Ok(())
     }
 
-    let index = unsafe { & *index };
+    let index = unsafe { &*index };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut w = BufWriter::new(File::create(path).unwrap());
 
-    let t : IoResult<()> = (|| {
+    let t: IoResult<()> = (|| {
         write_evaluation_domains(&index.domains, &mut w)?;
 
         for c in index.compiled.iter() {
@@ -268,7 +278,7 @@ pub extern "C" fn zexe_tweedle_fq_index_write<'a>(
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_index_read<'a>(
-    srs : *const SRS<GAffine>,
+    srs: *const SRS<GAffine>,
     a: *const Vec<(Vec<usize>, Vec<Fq>)>,
     b: *const Vec<(Vec<usize>, Vec<Fq>)>,
     c: *const Vec<(Vec<usize>, Vec<Fq>)>,
@@ -291,8 +301,8 @@ pub extern "C" fn zexe_tweedle_fq_index_read<'a>(
         let col_comm = read_poly_comm(&mut r)?;
         let row_comm = read_poly_comm(&mut r)?;
         let val_comm = read_poly_comm(&mut r)?;
-        let rc_comm =  read_poly_comm(&mut r)?;
-        let rc  = read_dense_polynomial(&mut r)?;
+        let rc_comm = read_poly_comm(&mut r)?;
+        let rc = read_dense_polynomial(&mut r)?;
         let row = read_dense_polynomial(&mut r)?;
         let col = read_dense_polynomial(&mut r)?;
         let val = read_dense_polynomial(&mut r)?;
@@ -302,33 +312,36 @@ pub extern "C" fn zexe_tweedle_fq_index_read<'a>(
         let row_eval_b = read_evaluations(&mut r)?;
         let col_eval_b = read_evaluations(&mut r)?;
         let val_eval_b = read_evaluations(&mut r)?;
-        let rc_eval_b  = read_evaluations(&mut r)?;
+        let rc_eval_b = read_evaluations(&mut r)?;
 
         Ok(marlin_protocol_dlog::compiled::Compiled {
             constraints,
-            col_comm   ,
-            row_comm   ,
-            val_comm   ,
-            rc_comm    ,
-            rc         ,
-            row        ,
-            col        ,
-            val        ,
-            row_eval_k ,
-            col_eval_k ,
-            val_eval_k ,
-            row_eval_b ,
-            col_eval_b ,
-            val_eval_b ,
-            rc_eval_b   })
+            col_comm,
+            row_comm,
+            val_comm,
+            rc_comm,
+            rc,
+            row,
+            col,
+            val,
+            row_eval_k,
+            col_eval_k,
+            val_eval_k,
+            row_eval_b,
+            col_eval_b,
+            val_eval_b,
+            rc_eval_b,
+        })
     }
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut r = BufReader::new(File::open(path).unwrap());
 
     let srs = unsafe { &*srs };
 
-    let t : IoResult<_> = (|| {
+    let t: IoResult<_> = (|| {
         let domains = read_evaluation_domains(&mut r)?;
 
         let c0 = read_compiled(public_inputs, domains, a, &mut r)?;
@@ -337,7 +350,7 @@ pub extern "C" fn zexe_tweedle_fq_index_read<'a>(
 
         let public_inputs = u64::read(&mut r)? as usize;
 
-        Ok( DlogIndex::<GAffine> {
+        Ok(DlogIndex::<GAffine> {
             compiled: [c0, c1, c2],
             domains,
             public_inputs,
@@ -354,16 +367,16 @@ pub extern "C" fn zexe_tweedle_fq_index_read<'a>(
 // Fq verifier index stubs
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_create(
-    index: *const DlogIndex<GAffine>
+    index: *const DlogIndex<GAffine>,
 ) -> *const DlogVerifierIndex<GAffine> {
-    Box::into_raw(Box::new(unsafe {&(*index)}.verifier_index()))
+    Box::into_raw(Box::new(unsafe { &(*index) }.verifier_index()))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_urs<'a>(
-    index: *const DlogVerifierIndex<'a, GAffine>
+    index: *const DlogVerifierIndex<'a, GAffine>,
 ) -> *const SRS<GAffine> {
-    let index = unsafe { & *index };
+    let index = unsafe { &*index };
     let urs = index.srs.get_ref().clone();
     Box::into_raw(Box::new(urs))
 }
@@ -391,9 +404,10 @@ pub extern "C" fn zexe_tweedle_fq_verifier_index_make<'a>(
     val_c: *const PolyComm<GAffine>,
     rc_c: *const PolyComm<GAffine>,
 ) -> *const DlogVerifierIndex<'a, GAffine> {
-    let srs : SRS<GAffine> = (unsafe { &*urs }).clone();
+    let srs: SRS<GAffine> = (unsafe { &*urs }).clone();
     let index = DlogVerifierIndex::<GAffine> {
-        domains: EvaluationDomains::create(variables, constraints, public_inputs, nonzero_entries).unwrap(),
+        domains: EvaluationDomains::create(variables, constraints, public_inputs, nonzero_entries)
+            .unwrap(),
         matrix_commitments: [
             marlin_protocol_dlog::index::MatrixValues {
                 row: (unsafe { &*row_a }).clone(),
@@ -424,22 +438,23 @@ pub extern "C" fn zexe_tweedle_fq_verifier_index_make<'a>(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_verifier_index_delete(
-    x: *mut DlogVerifierIndex<GAffine>
-) {
+pub extern "C" fn zexe_tweedle_fq_verifier_index_delete(x: *mut DlogVerifierIndex<GAffine>) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_write<'a>(
-    index : *const DlogVerifierIndex<GAffine>,
-    path: *const c_char) {
-    let index = unsafe { & *index };
+    index: *const DlogVerifierIndex<GAffine>,
+    path: *const c_char,
+) {
+    let index = unsafe { &*index };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut w = BufWriter::new(File::create(path).unwrap());
 
-    let t : IoResult<()> = (|| {
+    let t: IoResult<()> = (|| {
         for c in index.matrix_commitments.iter() {
             write_dlog_matrix_values(c, &mut w)?;
         }
@@ -453,14 +468,17 @@ pub extern "C" fn zexe_tweedle_fq_verifier_index_write<'a>(
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_read<'a>(
-    srs : *const SRS<GAffine>,
-    path: *const c_char) -> *const DlogVerifierIndex<'a, GAffine> {
+    srs: *const SRS<GAffine>,
+    path: *const c_char,
+) -> *const DlogVerifierIndex<'a, GAffine> {
     let srs = unsafe { &*srs };
 
-    let path = (unsafe { CStr::from_ptr(path) }).to_string_lossy().into_owned();
+    let path = (unsafe { CStr::from_ptr(path) })
+        .to_string_lossy()
+        .into_owned();
     let mut r = BufReader::new(File::open(path).unwrap());
 
-    let t : IoResult<_> = (|| {
+    let t: IoResult<_> = (|| {
         let m0 = read_dlog_matrix_values(&mut r)?;
         let m1 = read_dlog_matrix_values(&mut r)?;
         let m2 = read_dlog_matrix_values(&mut r)?;
@@ -484,84 +502,108 @@ pub extern "C" fn zexe_tweedle_fq_verifier_index_read<'a>(
 pub extern "C" fn zexe_tweedle_fq_verifier_index_a_row_comm(
     index: *const DlogVerifierIndex<GAffine>,
 ) -> *const PolyComm<GAffine> {
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].row }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_a_col_comm(
     index: *const DlogVerifierIndex<GAffine>,
 ) -> *const PolyComm<GAffine> {
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].col }).clone()))
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_a_val_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].val }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_a_rc_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[0].rc }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[0].rc }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_b_row_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].row }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_b_col_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].col }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_b_val_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].val }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_b_rc_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[1].rc }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[1].rc }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_c_row_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].row }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].row }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_c_col_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].col }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].col }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_c_val_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].val }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].val }).clone(),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_verifier_index_c_rc_comm(
     index: *const DlogVerifierIndex<GAffine>,
-) -> *const PolyComm<GAffine>{
-    Box::into_raw(Box::new((unsafe { &(*index).matrix_commitments[2].rc }).clone()))
+) -> *const PolyComm<GAffine> {
+    Box::into_raw(Box::new(
+        (unsafe { &(*index).matrix_commitments[2].rc }).clone(),
+    ))
 }
 
 // Fq stubs
@@ -909,9 +951,7 @@ pub extern "C" fn zexe_tweedle_dum_add(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dum_double(
-    x: *const GProjective,
-) -> *const GProjective {
+pub extern "C" fn zexe_tweedle_dum_double(x: *const GProjective) -> *const GProjective {
     let x_ = unsafe { &(*x) };
     let ret = x_.double();
     return Box::into_raw(Box::new(ret));
@@ -971,10 +1011,7 @@ pub extern "C" fn zexe_tweedle_dum_of_affine_coordinates(
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dum_affine_create(
-    x: *const Fp,
-    y: *const Fp
-    ) -> *const GAffine {
+pub extern "C" fn zexe_tweedle_dum_affine_create(x: *const Fp, y: *const Fp) -> *const GAffine {
     let x = (unsafe { *x }).clone();
     let y = (unsafe { *y }).clone();
     Box::into_raw(Box::new(GAffine::new(x, y, false)))
@@ -1005,22 +1042,22 @@ pub extern "C" fn zexe_tweedle_dum_affine_delete(x: *mut GAffine) {
 
 // G affine pair
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dum_affine_pair_0(
-    p: *const (GAffine, GAffine)) -> *const GAffine {
-    let (x0, _) = unsafe { *p};
+pub extern "C" fn zexe_tweedle_dum_affine_pair_0(p: *const (GAffine, GAffine)) -> *const GAffine {
+    let (x0, _) = unsafe { *p };
     return Box::into_raw(Box::new(x0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dum_affine_pair_1(
-    p: *const (GAffine, GAffine)) -> *const GAffine {
-    let (_, x1) = unsafe { *p};
+pub extern "C" fn zexe_tweedle_dum_affine_pair_1(p: *const (GAffine, GAffine)) -> *const GAffine {
+    let (_, x1) = unsafe { *p };
     return Box::into_raw(Box::new(x1.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dum_affine_pair_make(x0 : *const GAffine, x1 : *const GAffine)
--> *const (GAffine, GAffine) {
+pub extern "C" fn zexe_tweedle_dum_affine_pair_make(
+    x0: *const GAffine,
+    x1: *const GAffine,
+) -> *const (GAffine, GAffine) {
     let res = ((unsafe { *x0 }), (unsafe { *x1 }));
     return Box::into_raw(Box::new(res));
 }
@@ -1036,20 +1073,28 @@ pub extern "C" fn zexe_tweedle_dum_affine_pair_vector_create() -> *mut Vec<(GAff
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dum_affine_pair_vector_length(v: *const Vec<(GAffine, GAffine)>) -> i32 {
+pub extern "C" fn zexe_tweedle_dum_affine_pair_vector_length(
+    v: *const Vec<(GAffine, GAffine)>,
+) -> i32 {
     let v_ = unsafe { &(*v) };
     return v_.len() as i32;
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dum_affine_pair_vector_emplace_back(v: *mut Vec<(GAffine, GAffine)>, x: *const (GAffine, GAffine)) {
+pub extern "C" fn zexe_tweedle_dum_affine_pair_vector_emplace_back(
+    v: *mut Vec<(GAffine, GAffine)>,
+    x: *const (GAffine, GAffine),
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(*x_);
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dum_affine_pair_vector_get(v: *mut Vec<(GAffine, GAffine)>, i: u32) -> *mut (GAffine, GAffine) {
+pub extern "C" fn zexe_tweedle_dum_affine_pair_vector_get(
+    v: *mut Vec<(GAffine, GAffine)>,
+    i: u32,
+) -> *mut (GAffine, GAffine) {
     let v_ = unsafe { &mut (*v) };
     return Box::into_raw(Box::new((*v_)[i as usize]));
 }
@@ -1074,7 +1119,10 @@ pub extern "C" fn zexe_tweedle_dum_affine_vector_length(v: *const Vec<GAffine>) 
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_dum_affine_vector_emplace_back(v: *mut Vec<GAffine>, x: *const GAffine) {
+pub extern "C" fn zexe_tweedle_dum_affine_vector_emplace_back(
+    v: *mut Vec<GAffine>,
+    x: *const GAffine,
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(*x_);
@@ -1107,9 +1155,8 @@ pub extern "C" fn zexe_tweedle_fq_oracles_create(
     let index = unsafe { &(*index) };
     let proof = unsafe { &(*proof) };
 
-    let x_hat = 
-        evals_from_coeffs(proof.public.clone(), index.domains.x).interpolate();
-        // TODO: Should have no degree bound when we add the correct degree bound method
+    let x_hat = evals_from_coeffs(proof.public.clone(), index.domains.x).interpolate();
+    // TODO: Should have no degree bound when we add the correct degree bound method
     let x_hat_comm = index.srs.get_ref().commit(&x_hat, None);
 
     let (mut sponge, o) = proof
@@ -1118,97 +1165,88 @@ pub extern "C" fn zexe_tweedle_fq_oracles_create(
         );
     let opening_prechallenges = proof.proof.prechallenges(&mut sponge);
 
-    return Box::into_raw(Box::new(FqOracles { o, opening_prechallenges }));
+    return Box::into_raw(Box::new(FqOracles {
+        o,
+        opening_prechallenges,
+    }));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_oracles_opening_prechallenges(
-    oracles: *const FqOracles
+    oracles: *const FqOracles,
 ) -> *const Vec<Fq> {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).opening_prechallenges.iter().map(|x| x.0).collect() ));
+    return Box::into_raw(Box::new(
+        (unsafe { &(*oracles) })
+            .opening_prechallenges
+            .iter()
+            .map(|x| x.0)
+            .collect(),
+    ));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_oracles_alpha(
-    oracles: *const FqOracles
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.alpha.clone() ));
+pub extern "C" fn zexe_tweedle_fq_oracles_alpha(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.alpha.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_oracles_eta_a(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.eta_a.clone() ));
+pub extern "C" fn zexe_tweedle_fq_oracles_eta_a(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.eta_a.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_oracles_eta_b(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.eta_b.clone() ));
+pub extern "C" fn zexe_tweedle_fq_oracles_eta_b(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.eta_b.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_oracles_eta_c(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.eta_c.clone() ));
+pub extern "C" fn zexe_tweedle_fq_oracles_eta_c(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.eta_c.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_oracles_beta1(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.beta[0].0.clone() ));
+pub extern "C" fn zexe_tweedle_fq_oracles_beta1(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.beta[0].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_oracles_beta2(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.beta[1].0.clone() ));
+pub extern "C" fn zexe_tweedle_fq_oracles_beta2(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.beta[1].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_oracles_beta3(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.beta[2].0.clone() ));
+pub extern "C" fn zexe_tweedle_fq_oracles_beta3(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.beta[2].0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_oracles_polys(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.polys.0.clone() ));
+pub extern "C" fn zexe_tweedle_fq_oracles_polys(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.polys.0.clone()));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_oracles_evals(
-    oracles: *const FqOracles,
-) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.evals.0.clone() ));
+pub extern "C" fn zexe_tweedle_fq_oracles_evals(oracles: *const FqOracles) -> *const Fq {
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.evals.0.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_oracles_x_hat_nocopy(
     oracles: *const FqOracles,
 ) -> *const [Vec<Fq>; 3] {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.x_hat.clone() ));
+    return Box::into_raw(Box::new((unsafe { &(*oracles) }).o.x_hat.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_oracles_digest_before_evaluations(
     oracles: *const FqOracles,
 ) -> *const Fq {
-    return Box::into_raw(Box::new( (unsafe {&(*oracles)}).o.digest_before_evaluations.clone() ));
+    return Box::into_raw(Box::new(
+        (unsafe { &(*oracles) }).o.digest_before_evaluations.clone(),
+    ));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_oracles_delete(
-    x: *mut FqOracles,
-    ) {
+pub extern "C" fn zexe_tweedle_fq_oracles_delete(x: *mut FqOracles) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
@@ -1219,7 +1257,7 @@ pub extern "C" fn zexe_tweedle_fq_proof_create(
     primary_input: *const Vec<Fq>,
     auxiliary_input: *const Vec<Fq>,
     prev_challenges: *const Vec<Fq>,
-    prev_sgs : *const Vec<GAffine>,
+    prev_sgs: *const Vec<GAffine>,
 ) -> *const DlogProof<GAffine> {
     let index = unsafe { &(*index) };
     let primary_input = unsafe { &(*primary_input) };
@@ -1227,27 +1265,39 @@ pub extern "C" fn zexe_tweedle_fq_proof_create(
 
     let witness = prepare_witness(index.domains, primary_input, auxiliary_input);
 
-    let prev : Vec<(Vec<Fq>, PolyComm<GAffine>)> = {
-        let prev_challenges = unsafe { &*prev_challenges};
+    let prev: Vec<(Vec<Fq>, PolyComm<GAffine>)> = {
+        let prev_challenges = unsafe { &*prev_challenges };
         let prev_sgs = unsafe { &*prev_sgs };
-        if prev_challenges.len() == 0 {Vec::new()} else
-        {
+        if prev_challenges.len() == 0 {
+            Vec::new()
+        } else {
             let challenges_per_sg = prev_challenges.len() / prev_sgs.len();
-            prev_sgs.iter().enumerate().map( |(i, sg)| {
-                (
-                    prev_challenges[(i * challenges_per_sg)..(i+1)*challenges_per_sg].iter().map(|x| *x).collect(),
-                    PolyComm::<GAffine>{unshifted: vec![sg.clone()], shifted: None}
-                )
-            }).collect()
+            prev_sgs
+                .iter()
+                .enumerate()
+                .map(|(i, sg)| {
+                    (
+                        prev_challenges[(i * challenges_per_sg)..(i + 1) * challenges_per_sg]
+                            .iter()
+                            .map(|x| *x)
+                            .collect(),
+                        PolyComm::<GAffine> {
+                            unshifted: vec![sg.clone()],
+                            shifted: None,
+                        },
+                    )
+                })
+                .collect()
         }
     };
-    
+
     let rng = &mut rand_core::OsRng;
 
     let map = <GAffine as CommitmentCurve>::Map::setup();
-    let proof = DlogProof::create::<DefaultFqSponge<TweedledumParameters, MarlinSpongeConstants>, DefaultFrSponge<Fq, MarlinSpongeConstants>>(
-        &map, &witness, &index, prev, rng,
-    )
+    let proof = DlogProof::create::<
+        DefaultFqSponge<TweedledumParameters, MarlinSpongeConstants>,
+        DefaultFrSponge<Fq, MarlinSpongeConstants>,
+    >(&map, &witness, &index, prev, rng)
     .unwrap();
 
     return Box::into_raw(Box::new(proof));
@@ -1258,17 +1308,14 @@ pub extern "C" fn zexe_tweedle_fq_proof_verify(
     index: *const DlogVerifierIndex<GAffine>,
     proof: *const DlogProof<GAffine>,
 ) -> bool {
-
     let index = unsafe { &(*index) };
     let proof = unsafe { (*proof).clone() };
     let group_map = <GAffine as CommitmentCurve>::Map::setup();
 
-    DlogProof::verify::<DefaultFqSponge<TweedledumParameters, MarlinSpongeConstants>, DefaultFrSponge<Fq, MarlinSpongeConstants>>(
-        &group_map,
-        &[proof].to_vec(),
-        &index,
-        &mut rand_core::OsRng
-    )
+    DlogProof::verify::<
+        DefaultFqSponge<TweedledumParameters, MarlinSpongeConstants>,
+        DefaultFrSponge<Fq, MarlinSpongeConstants>,
+    >(&group_map, &[proof].to_vec(), &index, &mut rand_core::OsRng)
 }
 
 // TODO: Batch verify across different indexes
@@ -1281,65 +1328,72 @@ pub extern "C" fn zexe_tweedle_fq_proof_batch_verify(
     let proofs = unsafe { &(*proofs) };
     let group_map = <GAffine as CommitmentCurve>::Map::setup();
 
-    DlogProof::<GAffine>::verify::<DefaultFqSponge<TweedledumParameters, MarlinSpongeConstants>, DefaultFrSponge<Fq, MarlinSpongeConstants>>(
-        &group_map,
-        proofs,
-        index,
-        &mut rand_core::OsRng,
-    )
+    DlogProof::<GAffine>::verify::<
+        DefaultFqSponge<TweedledumParameters, MarlinSpongeConstants>,
+        DefaultFrSponge<Fq, MarlinSpongeConstants>,
+    >(&group_map, proofs, index, &mut rand_core::OsRng)
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_proof_make(
-    primary_input : *const Vec<Fq>,
+    primary_input: *const Vec<Fq>,
 
-    w_comm        : *const PolyComm<GAffine>,
-    za_comm       : *const PolyComm<GAffine>,
-    zb_comm       : *const PolyComm<GAffine>,
-    h1_comm       : *const PolyComm<GAffine>,
-    g1_comm       : *const PolyComm<GAffine>,
-    h2_comm       : *const PolyComm<GAffine>,
-    g2_comm       : *const PolyComm<GAffine>,
-    h3_comm       : *const PolyComm<GAffine>,
-    g3_comm       : *const PolyComm<GAffine>,
+    w_comm: *const PolyComm<GAffine>,
+    za_comm: *const PolyComm<GAffine>,
+    zb_comm: *const PolyComm<GAffine>,
+    h1_comm: *const PolyComm<GAffine>,
+    g1_comm: *const PolyComm<GAffine>,
+    h2_comm: *const PolyComm<GAffine>,
+    g2_comm: *const PolyComm<GAffine>,
+    h3_comm: *const PolyComm<GAffine>,
+    g3_comm: *const PolyComm<GAffine>,
 
-    sigma2        : *const Fq,
-    sigma3        : *const Fq, 
+    sigma2: *const Fq,
+    sigma3: *const Fq,
 
-    lr : *const Vec<(GAffine, GAffine)>,
-    z1 : *const Fq,
-    z2 : *const Fq,
-    delta : *const GAffine,
-    sg : *const GAffine,
+    lr: *const Vec<(GAffine, GAffine)>,
+    z1: *const Fq,
+    z2: *const Fq,
+    delta: *const GAffine,
+    sg: *const GAffine,
 
-    evals0 : *const DlogProofEvaluations<Fq>,
-    evals1 : *const DlogProofEvaluations<Fq>,
-    evals2 : *const DlogProofEvaluations<Fq>,
+    evals0: *const DlogProofEvaluations<Fq>,
+    evals1: *const DlogProofEvaluations<Fq>,
+    evals2: *const DlogProofEvaluations<Fq>,
 
     prev_challenges: *const Vec<Fq>,
-    prev_sgs : *const Vec<GAffine>,
-    ) -> *const DlogProof<GAffine> {
-
+    prev_sgs: *const Vec<GAffine>,
+) -> *const DlogProof<GAffine> {
     let public = unsafe { &(*primary_input) }.clone();
     // public.resize(ceil_pow2(public.len()), Fq::zero());
 
-    let prev : Vec<(Vec<Fq>, PolyComm<GAffine>)> = {
-        let prev_challenges = unsafe { &*prev_challenges};
+    let prev: Vec<(Vec<Fq>, PolyComm<GAffine>)> = {
+        let prev_challenges = unsafe { &*prev_challenges };
         let prev_sgs = unsafe { &*prev_sgs };
-        if prev_challenges.len() == 0 {Vec::new()} else
-        {
+        if prev_challenges.len() == 0 {
+            Vec::new()
+        } else {
             let challenges_per_sg = prev_challenges.len() / prev_sgs.len();
-            prev_sgs.iter().enumerate().map( |(i, sg)| {
-                (
-                    prev_challenges[(i * challenges_per_sg)..(i+1)*challenges_per_sg].iter().map(|x| *x).collect(),
-                    PolyComm::<GAffine>{unshifted: vec![sg.clone()], shifted: None}
-                )
-            }).collect()
+            prev_sgs
+                .iter()
+                .enumerate()
+                .map(|(i, sg)| {
+                    (
+                        prev_challenges[(i * challenges_per_sg)..(i + 1) * challenges_per_sg]
+                            .iter()
+                            .map(|x| *x)
+                            .collect(),
+                        PolyComm::<GAffine> {
+                            unshifted: vec![sg.clone()],
+                            shifted: None,
+                        },
+                    )
+                })
+                .collect()
         }
     };
 
     let res = DlogProof {
-
         prev_challenges: prev,
         proof: OpeningProof {
             lr: (unsafe { &*lr }).clone(),
@@ -1349,20 +1403,24 @@ pub extern "C" fn zexe_tweedle_fq_proof_make(
             sg: (unsafe { *sg }).clone(),
         },
         w_comm: (unsafe { &*w_comm }).clone(),
-        za_comm: (unsafe { &*za_comm }).clone() ,
-        zb_comm: (unsafe { &*zb_comm }).clone() ,
-        h1_comm: (unsafe { &*h1_comm }).clone() ,
+        za_comm: (unsafe { &*za_comm }).clone(),
+        zb_comm: (unsafe { &*zb_comm }).clone(),
+        h1_comm: (unsafe { &*h1_comm }).clone(),
         g1_comm: (unsafe { &*g1_comm }).clone(),
-        h2_comm: (unsafe { &*h2_comm }).clone() ,
+        h2_comm: (unsafe { &*h2_comm }).clone(),
         g2_comm: (unsafe { &*g2_comm }).clone(),
-        h3_comm: (unsafe { &*h3_comm }).clone() ,
+        h3_comm: (unsafe { &*h3_comm }).clone(),
         g3_comm: (unsafe { &*g3_comm }).clone(),
 
         sigma2: (unsafe { *sigma2 }).clone(),
         sigma3: (unsafe { *sigma3 }).clone(),
 
         public,
-        evals: [(unsafe { &*evals0 }).clone(), (unsafe {& *evals1 }).clone(), (unsafe { &*evals2 }).clone(), ],
+        evals: [
+            (unsafe { &*evals0 }).clone(),
+            (unsafe { &*evals1 }).clone(),
+            (unsafe { &*evals2 }).clone(),
+        ],
     };
     return Box::into_raw(Box::new(res));
 }
@@ -1373,55 +1431,73 @@ pub extern "C" fn zexe_tweedle_fq_proof_delete(x: *mut DlogProof<GAffine>) {
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_w_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe { &((*p).w_comm )}).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_w_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).w_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_za_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).za_comm )}).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_za_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).za_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_zb_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).zb_comm )}).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_zb_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).zb_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_h1_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).h1_comm )}).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_h1_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).h1_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_g1_comm_nocopy(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_tweedle_fq_proof_g1_comm_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).g1_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_h2_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
-    let x = (unsafe {&((*p).h2_comm )}).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_h2_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
+    let x = (unsafe { &((*p).h2_comm) }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_g2_comm_nocopy(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_tweedle_fq_proof_g2_comm_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).g2_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_h3_comm(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_tweedle_fq_proof_h3_comm(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).h3_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_g3_comm_nocopy(p: *mut DlogProof<GAffine>) -> *const PolyComm<GAffine> {
+pub extern "C" fn zexe_tweedle_fq_proof_g3_comm_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const PolyComm<GAffine> {
     let x = (unsafe { &(*p).g3_comm }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1439,13 +1515,17 @@ pub extern "C" fn zexe_tweedle_fq_proof_sigma3(p: *mut DlogProof<GAffine>) -> *c
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_proof(p: *mut DlogProof<GAffine>) -> *const OpeningProof<GAffine> {
+pub extern "C" fn zexe_tweedle_fq_proof_proof(
+    p: *mut DlogProof<GAffine>,
+) -> *const OpeningProof<GAffine> {
     let x = (unsafe { &(*p).proof }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evals_nocopy(p: *mut DlogProof<GAffine>) -> *const [DlogProofEvaluations<Fq>; 3] {
+pub extern "C" fn zexe_tweedle_fq_proof_evals_nocopy(
+    p: *mut DlogProof<GAffine>,
+) -> *const [DlogProofEvaluations<Fq>; 3] {
     let x = (unsafe { &(*p).evals }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1464,14 +1544,20 @@ pub extern "C" fn zexe_tweedle_fq_proof_vector_length(v: *const Vec<DlogProof<GA
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_vector_emplace_back(v: *mut Vec<DlogProof<GAffine>>, x: *const DlogProof<GAffine>) {
+pub extern "C" fn zexe_tweedle_fq_proof_vector_emplace_back(
+    v: *mut Vec<DlogProof<GAffine>>,
+    x: *const DlogProof<GAffine>,
+) {
     let v_ = unsafe { &mut (*v) };
     let x_ = unsafe { &(*x) };
     v_.push(x_.clone());
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_vector_get(v: *mut Vec<DlogProof<GAffine>>, i: u32) -> *mut DlogProof<GAffine> {
+pub extern "C" fn zexe_tweedle_fq_proof_vector_get(
+    v: *mut Vec<DlogProof<GAffine>>,
+    i: u32,
+) -> *mut DlogProof<GAffine> {
     let v_ = unsafe { &mut (*v) };
     return Box::into_raw(Box::new((*v_)[i as usize].clone()));
 }
@@ -1492,13 +1578,17 @@ pub extern "C" fn zexe_tweedle_fq_opening_proof_delete(p: *mut OpeningProof<GAff
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_opening_proof_sg(p: *const OpeningProof<GAffine>) -> *const GAffine {
+pub extern "C" fn zexe_tweedle_fq_opening_proof_sg(
+    p: *const OpeningProof<GAffine>,
+) -> *const GAffine {
     let x = (unsafe { &(*p).sg }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_opening_proof_lr(p: *const OpeningProof<GAffine>) -> *const Vec<(GAffine, GAffine)> {
+pub extern "C" fn zexe_tweedle_fq_opening_proof_lr(
+    p: *const OpeningProof<GAffine>,
+) -> *const Vec<(GAffine, GAffine)> {
     let x = (unsafe { &(*p).lr }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1516,7 +1606,9 @@ pub extern "C" fn zexe_tweedle_fq_opening_proof_z2(p: *const OpeningProof<GAffin
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_opening_proof_delta(p: *const OpeningProof<GAffine>) -> *const GAffine {
+pub extern "C" fn zexe_tweedle_fq_opening_proof_delta(
+    p: *const OpeningProof<GAffine>,
+) -> *const GAffine {
     let x = (unsafe { &(*p).delta }).clone();
     return Box::into_raw(Box::new(x));
 }
@@ -1524,103 +1616,137 @@ pub extern "C" fn zexe_tweedle_fq_opening_proof_delta(p: *const OpeningProof<GAf
 // Fq proof evaluations
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_w(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).w }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_w(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).w }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_za(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).za }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_za(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).za }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_zb(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).zb }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_zb(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).zb }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_h1(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).h1 }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_h1(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).h1 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_h2(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).h2 }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_h2(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).h2 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_h3(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).h3 }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_h3(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).h3 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_g1(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).g1 }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_g1(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).g1 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_g2(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).g2 }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_g2(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).g2 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_g3(e: *const DlogProofEvaluations<Fq>) -> *const Vec<Fq> {
-    let x = (unsafe { & (*e).g3 }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_g3(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const Vec<Fq> {
+    let x = (unsafe { &(*e).g3 }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_row_nocopy(e: *const DlogProofEvaluations<Fq>) -> *const [Vec<Fq>; 3] {
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_row_nocopy(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const [Vec<Fq>; 3] {
     let x = (unsafe { &(*e).row }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_val_nocopy(e: *const DlogProofEvaluations<Fq>) -> *const [Vec<Fq>; 3] {
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_val_nocopy(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const [Vec<Fq>; 3] {
     let x = (unsafe { &(*e).val }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_col_nocopy(e: *const DlogProofEvaluations<Fq>) -> *const [Vec<Fq>; 3] {
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_col_nocopy(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const [Vec<Fq>; 3] {
     let x = (unsafe { &(*e).col }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_rc_nocopy(e: *const DlogProofEvaluations<Fq>) -> *const [Vec<Fq>; 3] {
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_rc_nocopy(
+    e: *const DlogProofEvaluations<Fq>,
+) -> *const [Vec<Fq>; 3] {
     let x = (unsafe { &(*e).rc }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_triple_0(e: *const [DlogProofEvaluations<Fq>; 3]) -> *const DlogProofEvaluations<Fq> {
-    let x = (unsafe { & (*e)[0] }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_triple_0(
+    e: *const [DlogProofEvaluations<Fq>; 3],
+) -> *const DlogProofEvaluations<Fq> {
+    let x = (unsafe { &(*e)[0] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_triple_1(e: *const [DlogProofEvaluations<Fq>; 3]) -> *const DlogProofEvaluations<Fq> {
-    let x = (unsafe { & (*e)[1] }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_triple_1(
+    e: *const [DlogProofEvaluations<Fq>; 3],
+) -> *const DlogProofEvaluations<Fq> {
+    let x = (unsafe { &(*e)[1] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_triple_2(e: *const [DlogProofEvaluations<Fq>; 3]) -> *const DlogProofEvaluations<Fq> {
-    let x = (unsafe { & (*e)[2] }).clone();
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_triple_2(
+    e: *const [DlogProofEvaluations<Fq>; 3],
+) -> *const DlogProofEvaluations<Fq> {
+    let x = (unsafe { &(*e)[2] }).clone();
     return Box::into_raw(Box::new(x));
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_proof_evaluations_triple_delete(x: *mut [DlogProofEvaluations<Fq>; 3]) {
+pub extern "C" fn zexe_tweedle_fq_proof_evaluations_triple_delete(
+    x: *mut [DlogProofEvaluations<Fq>; 3],
+) {
     let _box = unsafe { Box::from_raw(x) };
 }
 
@@ -1650,8 +1776,9 @@ pub extern "C" fn zexe_tweedle_fq_proof_evaluations_make(
 
     rc_0: *const Vec<Fq>,
     rc_1: *const Vec<Fq>,
-    rc_2: *const Vec<Fq>) -> *const DlogProofEvaluations<Fq> {
-    let res : DlogProofEvaluations<Fq> = DlogProofEvaluations {
+    rc_2: *const Vec<Fq>,
+) -> *const DlogProofEvaluations<Fq> {
+    let res: DlogProofEvaluations<Fq> = DlogProofEvaluations {
         w: (unsafe { &*w }).clone(),
         za: (unsafe { &*za }).clone(),
         zb: (unsafe { &*zb }).clone(),
@@ -1661,22 +1788,26 @@ pub extern "C" fn zexe_tweedle_fq_proof_evaluations_make(
         h1: (unsafe { &*h1 }).clone(),
         h2: (unsafe { &*h2 }).clone(),
         h3: (unsafe { &*h3 }).clone(),
-        row:
-            [ (unsafe {&*row_0}).clone(),
-                (unsafe {&*row_1}).clone(),
-                (unsafe {&*row_2}).clone() ],
-        col:
-            [ (unsafe {&*col_0}).clone(),
-                (unsafe {&*col_1}).clone(),
-                (unsafe {&*col_2}).clone() ],
-        val:
-            [ (unsafe {&*val_0}).clone(),
-                (unsafe {&*val_1}).clone(),
-                (unsafe {&*val_2}).clone() ],
-        rc:
-            [ (unsafe {&*rc_0}).clone(),
-                (unsafe {&*rc_1}).clone(),
-                (unsafe {&*rc_2}).clone() ],
+        row: [
+            (unsafe { &*row_0 }).clone(),
+            (unsafe { &*row_1 }).clone(),
+            (unsafe { &*row_2 }).clone(),
+        ],
+        col: [
+            (unsafe { &*col_0 }).clone(),
+            (unsafe { &*col_1 }).clone(),
+            (unsafe { &*col_2 }).clone(),
+        ],
+        val: [
+            (unsafe { &*val_0 }).clone(),
+            (unsafe { &*val_1 }).clone(),
+            (unsafe { &*val_2 }).clone(),
+        ],
+        rc: [
+            (unsafe { &*rc_0 }).clone(),
+            (unsafe { &*rc_1 }).clone(),
+            (unsafe { &*rc_2 }).clone(),
+        ],
     };
 
     return Box::into_raw(Box::new(res));
@@ -1689,33 +1820,39 @@ pub extern "C" fn zexe_tweedle_fq_proof_evaluations_delete(x: *mut DlogProofEval
 
 // fq poly comm
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_poly_comm_unshifted(c: *const PolyComm<GAffine>) -> *const Vec<GAffine> {
-    let c = unsafe {& (*c) };
+pub extern "C" fn zexe_tweedle_fq_poly_comm_unshifted(
+    c: *const PolyComm<GAffine>,
+) -> *const Vec<GAffine> {
+    let c = unsafe { &(*c) };
     return Box::into_raw(Box::new(c.unshifted.clone()));
 }
 
 #[no_mangle]
 pub extern "C" fn zexe_tweedle_fq_poly_comm_shifted(c: *const PolyComm<GAffine>) -> *const GAffine {
-    let c = unsafe {& (*c) };
+    let c = unsafe { &(*c) };
     match c.shifted {
         Some(g) => Box::into_raw(Box::new(g.clone())),
-        None =>  std::ptr::null()
+        None => std::ptr::null(),
     }
 }
 
 #[no_mangle]
-pub extern "C" fn zexe_tweedle_fq_poly_comm_make
-(
+pub extern "C" fn zexe_tweedle_fq_poly_comm_make(
     unshifted: *const Vec<GAffine>,
-    shifted: *const GAffine
-) -> *const PolyComm<GAffine>
-{
-    let unsh = unsafe {& (*unshifted) };
+    shifted: *const GAffine,
+) -> *const PolyComm<GAffine> {
+    let unsh = unsafe { &(*unshifted) };
 
-    let commitment = PolyComm
-    {
+    let commitment = PolyComm {
         unshifted: unsh.clone(),
-        shifted: if shifted == std::ptr::null() {None} else {Some ({let sh = unsafe {& (*shifted) }; *sh})}
+        shifted: if shifted == std::ptr::null() {
+            None
+        } else {
+            Some({
+                let sh = unsafe { &(*shifted) };
+                *sh
+            })
+        },
     };
 
     Box::into_raw(Box::new(commitment))


### PR DESCRIPTION
This makes changes to the rust code between branches less aggressively incompatible.