### PR TITLE
Upgrade ocaml-rs

### DIFF
--- a/algebra-core/Cargo.toml
+++ b/algebra-core/Cargo.toml
@@ -26,7 +26,7 @@ build = "build.rs"
 algebra-core-derive = { path = "algebra-core-derive", optional = true }
 derivative = { version = "2", features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }
-ocaml = { version = "0.18.1", optional = true }
+ocaml = { version = "0.22.0", optional = true }
 rand = { version = "0.7", default-features = false }
 rayon = { version = "1", optional = true }
 unroll = "0.1.4"

--- a/algebra-core/src/biginteger/macros.rs
+++ b/algebra-core/src/biginteger/macros.rs
@@ -290,7 +290,7 @@ macro_rules! bigint_impl {
         }
 
         #[cfg(feature = "ocaml_types")]
-        unsafe impl ocaml::FromValue for $name {
+        unsafe impl<'a> ocaml::FromValue<'a> for $name {
             fn from_value(value: ocaml::Value) -> Self {
                 let x: ocaml::Pointer<Self> = ocaml::FromValue::from_value(value);
                 x.as_ref().clone()
@@ -299,9 +299,9 @@ macro_rules! bigint_impl {
 
         #[cfg(feature = "ocaml_types")]
         impl $name {
-            extern "C" fn ocaml_compare (x: ocaml::Value, y: ocaml::Value) -> i32 {
-                let x: ocaml::Pointer<$name> = ocaml::FromValue::from_value(x);
-                let y: ocaml::Pointer<$name> = ocaml::FromValue::from_value(y);
+            extern "C" fn ocaml_compare (x: ocaml::Raw, y: ocaml::Raw) -> i32 {
+                let x: ocaml::Pointer<$name> = unsafe { x.as_pointer() };
+                let y: ocaml::Pointer<$name> = unsafe { y.as_pointer() };
                 match x.as_ref().cmp(y.as_ref()) {
                     core::cmp::Ordering::Less => -1,
                     core::cmp::Ordering::Equal => 0,

--- a/algebra-core/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra-core/src/curves/models/short_weierstrass_jacobian.rs
@@ -43,27 +43,27 @@ pub struct GroupAffine<P: Parameters> {
 }
 
 #[cfg(feature = "ocaml_types")]
-#[derive(ocaml::ToValue, ocaml::FromValue)]
+#[derive(ocaml::IntoValue, ocaml::FromValue)]
 enum CamlGroupAffine<T> {
     Infinity,
     Finite((T, T)),
 }
 
 #[cfg(feature = "ocaml_types")]
-unsafe impl<P: Parameters> ocaml::ToValue for GroupAffine<P> where
-    P::BaseField: ocaml::ToValue {
-    fn to_value(self) -> ocaml::Value {
+unsafe impl<P: Parameters> ocaml::IntoValue for GroupAffine<P> where
+    P::BaseField: ocaml::IntoValue {
+    fn into_value(self, runtime: &ocaml::Runtime) -> ocaml::Value {
         if self.infinity {
-           ocaml::ToValue::to_value(CamlGroupAffine::<P::BaseField>::Infinity)
+           ocaml::IntoValue::into_value(CamlGroupAffine::<P::BaseField>::Infinity, runtime)
         } else {
-           ocaml::ToValue::to_value(CamlGroupAffine::Finite((self.x, self.y)))
+           ocaml::IntoValue::into_value(CamlGroupAffine::Finite((self.x, self.y)), runtime)
         }
     }
 }
 
 #[cfg(feature = "ocaml_types")]
-unsafe impl<P: Parameters> ocaml::FromValue for GroupAffine<P> where
-    P::BaseField: ocaml::FromValue {
+unsafe impl<'a, P: Parameters> ocaml::FromValue<'a> for GroupAffine<P> where
+    P::BaseField: ocaml::FromValue<'a> {
     fn from_value(v: ocaml::Value) -> Self {
         let g: CamlGroupAffine<P::BaseField> = ocaml::FromValue::from_value(v);
         match g {
@@ -428,7 +428,7 @@ impl<P: Parameters> ocaml::Custom for GroupProjective<P> {
 }
 
 #[cfg(feature = "ocaml_types")]
-unsafe impl<P: Parameters> ocaml::FromValue for GroupProjective<P> {
+unsafe impl<'a, P: Parameters> ocaml::FromValue<'a> for GroupProjective<P> {
     fn from_value(v: ocaml::Value) -> Self {
         let x: ocaml::Pointer<Self> = ocaml::FromValue::from_value(v);
         x.as_ref().clone()

--- a/algebra-core/src/fields/macros.rs
+++ b/algebra-core/src/fields/macros.rs
@@ -455,7 +455,7 @@ macro_rules! impl_Fp {
         }
 
         #[cfg(feature = "ocaml_types")]
-        unsafe impl<P> ocaml::FromValue for $Fp<P> {
+        unsafe impl<'a, P> ocaml::FromValue<'a> for $Fp<P> {
             fn from_value(value: ocaml::Value) -> Self {
                 let x: ocaml::Pointer<Self> = ocaml::FromValue::from_value(value);
                 x.as_ref().clone()
@@ -464,9 +464,9 @@ macro_rules! impl_Fp {
 
         #[cfg(feature = "ocaml_types")]
         impl<P: $FpParameters> $Fp<P> {
-            extern "C" fn ocaml_compare (x: ocaml::Value, y: ocaml::Value) -> i32 {
-                let x: ocaml::Pointer<$Fp<P>> = ocaml::FromValue::from_value(x);
-                let y: ocaml::Pointer<$Fp<P>> = ocaml::FromValue::from_value(y);
+            extern "C" fn ocaml_compare (x: ocaml::Raw, y: ocaml::Raw) -> i32 {
+                let x: ocaml::Pointer<$Fp<P>> = unsafe { x.as_pointer() };
+                let y: ocaml::Pointer<$Fp<P>> = unsafe { y.as_pointer() };
                 match x.as_ref().cmp(y.as_ref()) {
                     core::cmp::Ordering::Less => -1,
                     core::cmp::Ordering::Equal => 0,


### PR DESCRIPTION
This PR bumps the version of the `ocaml` rust library to 0.22.0. This version includes a fix for an issue suspected of causing memory corruption issues in the mina daemon.